### PR TITLE
Gettable datetime filter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 	</parent>
 	<groupId>com.milmove.trdmlambda</groupId>
 	<artifactId>trdm-lambda</artifactId>
-	<version>0.4.0.1</version>
+	<version>0.4.1.0</version>
 	<name>trdm java spring interface</name>
 	<description>Project for deploying a Java RESTful interface for SOAP requests to TRDM.</description>
 	<properties>

--- a/src/main/java/com/milmove/trdmlambda/milmove/model/gettable/GetTableRequest.java
+++ b/src/main/java/com/milmove/trdmlambda/milmove/model/gettable/GetTableRequest.java
@@ -1,5 +1,7 @@
 package com.milmove.trdmlambda.milmove.model.gettable;
 
+import javax.xml.datatype.XMLGregorianCalendar;
+
 import com.milmove.trdmlambda.milmove.contraints.ContentUpdatedSinceDateTimeConstraint;
 import com.milmove.trdmlambda.milmove.contraints.PhysicalNameConstraint;
 
@@ -12,4 +14,7 @@ public class GetTableRequest {
     @ContentUpdatedSinceDateTimeConstraint
     private String contentUpdatedSinceDateTime; // To be converted to javax.xml.datatype.XMLGregorianCalendar
     private boolean returnContent;
+    // Optional date time filters to be used in specific range requests
+    private XMLGregorianCalendar firstDateTimeFilter;
+    private XMLGregorianCalendar secondDateTimeFilter;
 }

--- a/src/main/java/com/milmove/trdmlambda/milmove/util/DecodeKeystore.java
+++ b/src/main/java/com/milmove/trdmlambda/milmove/util/DecodeKeystore.java
@@ -25,6 +25,8 @@ public class DecodeKeystore {
 
         if (file.exists()) {
             logger.info("Keystore file already exists. Not recreating");
+            System.setProperty("javax.net.ssl.keyStore", filepath);
+            System.setProperty("javax.net.ssl.keyStorePassword", this.password);
             return;
         }
 

--- a/src/main/java/com/milmove/trdmlambda/milmove/util/DecodeTruststore.java
+++ b/src/main/java/com/milmove/trdmlambda/milmove/util/DecodeTruststore.java
@@ -26,6 +26,9 @@ public class DecodeTruststore {
 
         if (file.exists()) {
             logger.info("Truststore file already exists. Not recreating");
+            // Set system properties for truststore
+            System.setProperty("javax.net.ssl.trustStore", filepath);
+            System.setProperty("javax.net.ssl.trustStorePassword", password);
             return;
         }
 


### PR DESCRIPTION
[Epic](https://www13.v1host.com/USTRANSCOM38/Epic.mvc/Summary?oidToken=Epic%3a810602)
* Increase version to 0.4.1.0
* Add conditional check for date time value ranges provided
  * Added TwoValueDateTimeFilter usage should these be provided to request specific date ranges of data from TRDM
* Added proper system settings if trust store and keypair store is found to already be existing
  
 Example output:
```
<soapenv:Envelope xmlns:ret="http://trdm/ReturnTableService" xmlns:soapenv="http://www.w3.org/2003/05/soap-envelope">
   <soapenv:Header/>
   <soapenv:Body>
      <ret:getTableRequestElement>
         <ret:input>
            <ret:TRDM>
               <ret:physicalName>LN_OF_ACCT</ret:physicalName>
               <ret:returnContent>true</ret:returnContent>
               <ret:columnFilters>
                  <ret:columnFilter>
                     <ret:column>LAST_UDP_DT</ret:column>
                     <ret:columnFilterTypes>
                        <ret:twoValueDateTimeFilter>
                           <ret:filterType>IS_BETWEEN</ret:filterType>
                           <ret:filterValue>2023-08-01T00:00:00.000Z</ret:filterValue>
                           <ret:filterValue>2023-00-31T23:59:59.999Z</ret:filterValue>
                        </ret:twoValueDateTimeFilter>
                     </ret:columnFilterTypes>
                  </ret:columnFilter>
               </ret:columnFilters>
            </ret:TRDM>
         </ret:input>
      </ret:getTableRequestElement>
   </soapenv:Body>
</soapenv:Envelope>
```


The following has not been implemented yet:
```
<ret:returnRowStatus></ret:returnRowStatus>
<ret:returnLastUpdate></ret:returnLastUpdate>
```
