### PR TITLE
B-19842: Duplicate data protection – Allow updating – Wrap in Transaction

### DIFF
--- a/src/main/java/com/milmove/trdmlambda/milmove/constants/LinesOfAccountingDatabaseColumns.java
+++ b/src/main/java/com/milmove/trdmlambda/milmove/constants/LinesOfAccountingDatabaseColumns.java
@@ -1,0 +1,70 @@
+package com.milmove.trdmlambda.milmove.constants;
+
+public final class LinesOfAccountingDatabaseColumns {
+
+    private LinesOfAccountingDatabaseColumns() {
+            // restrict instantiation
+    }
+
+    public static final String id = "id";
+    public static final String loaSysId = "loa_sys_id";
+    public static final String loaDptId = "loa_dpt_id";
+    public static final String loaTnsfrDptNm = "loa_tnsfr_dpt_nm";
+    public static final String loaBafId = "loa_baf_id";
+    public static final String loaTrsySfxTx = "loa_trsy_sfx_tx";
+    public static final String loaMajClmNm = "loa_maj_clm_nm";
+    public static final String loaOpAgncy_id = "loa_op_agncy_id";
+    public static final String loaAlltSnId = "loa_allt_sn_id";
+    public static final String loaPgmElmntId = "loa_pgm_elmnt_id";
+    public static final String loaTskBdgtSblnTx = "loa_tsk_bdgt_sbln_tx";
+    public static final String loaDfAgncyAlctnRcpntId = "loa_df_agncy_alctn_rcpnt_id";
+    public static final String loaJbOrdNm = "loa_jb_ord_nm";
+    public static final String loaSbaltmtRcpntId = "loa_sbaltmt_rcpnt_id";
+    public static final String loaWkCntrRcpntNm = "loa_wk_cntr_rcpnt_nm";
+    public static final String loaMajRmbsmtSrcId = "loa_maj_rmbsmt_src_id";
+    public static final String loaDtlRmbsmtSrcId = "loa_dtl_rmbsmt_src_id";
+    public static final String loaCustNm = "loa_cust_nm";
+    public static final String loaObjClsId = "loa_obj_cls_id";
+    public static final String loaSrvSrcId = "loa_srv_src_id";
+    public static final String loaSpclIntrId = "loa_spcl_intr_id";
+    public static final String loaBdgtAcntClsNm = "loa_bdgt_acnt_cls_nm";
+    public static final String loaDocId = "loa_doc_id";
+    public static final String loaClsRefId = "loa_cls_ref_id";
+    public static final String loaInstlAcntgActId = "loa_instl_acntg_act_id";
+    public static final String loaLclInstlId = "loa_lcl_instl_id";
+    public static final String loaFmsTrnsactnId = "loa_fms_trnsactn_id";
+    public static final String loaDscTx = "loa_dsc_tx";
+    public static final String loaBgnDt = "loa_bgn_dt";
+    public static final String loaEndDt = "loa_end_dt";
+    public static final String loaFnctPrsNm = "loa_fnct_prs_nm";
+    public static final String loaStatCd = "loa_stat_cd";
+    public static final String loaHistStatCd = "loa_hist_stat_cd";
+    public static final String loaHsGdsCd = "loa_hs_gds_cd";
+    public static final String orgGrpDfasCd = "org_grp_dfas_cd";
+    public static final String loaUic = "loa_uic";
+    public static final String loaTrnsnId = "loa_trnsn_id";
+    public static final String loaSubAcntId = "loa_sub_acnt_id";
+    public static final String loaBetCd = "loa_bet_cd";
+    public static final String loaFndTyFgCd = "loa_fnd_ty_fg_cd";
+    public static final String loaBgtLnItmId = "loa_bgt_ln_itm_id";
+    public static final String loaScrtyCoopImplAgncCd = "loa_scrty_coop_impl_agnc_cd";
+    public static final String loaScrtyCoopDsgntrCd = "loa_scrty_coop_dsgntr_cd";
+    public static final String loaScrtyCoopLnItmId = "loa_scrty_coop_ln_itm_id";
+    public static final String loaAgncDsbrCd = "loa_agnc_dsbr_cd";
+    public static final String loaAgncAcntngCd = "loa_agnc_acntng_cd";
+    public static final String loaFndCntrId = "loa_fnd_cntr_id";
+    public static final String loaCstCntrId = "loa_cst_cntr_id";
+    public static final String loaPrjId = "loa_prj_id";
+    public static final String loaActvtyId = "loa_actvty_id";
+    public static final String loaCstCd = "loa_cst_cd";
+    public static final String loaWrkOrdId = "loa_wrk_ord_id";
+    public static final String loaFnclArId = "loa_fncl_ar_id";
+    public static final String loaScrtyCoopCustCd = "loa_scrty_coop_cust_cd";
+    public static final String loaEndFyTx = "loa_end_fy_tx";
+    public static final String loaBgFyTx = "loa_bg_fy_tx";
+    public static final String loaBgtRstrCd = "loa_bgt_rstr_cd";
+    public static final String loaBgtSubActCd = "loa_bgt_sub_act_cd";
+    public static final String createdAt = "created_at";
+    public static final String updatedAt = "updated_at";
+    public static final String validHhgCodeForLoa = "valid_hhg_code_for_loa";
+}

--- a/src/main/java/com/milmove/trdmlambda/milmove/constants/TransportationAccountingCodesDatabaseColumns.java
+++ b/src/main/java/com/milmove/trdmlambda/milmove/constants/TransportationAccountingCodesDatabaseColumns.java
@@ -1,0 +1,38 @@
+package com.milmove.trdmlambda.milmove.constants;
+
+public final class TransportationAccountingCodesDatabaseColumns {
+
+    private TransportationAccountingCodesDatabaseColumns() {
+            // restrict instantiation
+    }
+
+    public static final String id = "id";
+    public static final String tac = "tac";
+    public static final String createdAt = "created_at";
+    public static final String updatedAt = "updated_at";
+    public static final String loaId = "loa_id";
+    public static final String tacSysId = "tac_sys_id";
+    public static final String loaSysId = "loa_sys_id";
+    public static final String tacFyTxt = "tac_fy_txt";
+    public static final String tacFnBlModCd = "tac_fn_bl_mod_cd";
+    public static final String orgGrpDfasCd = "org_grp_dfas_cd";
+    public static final String tacMvtDsgId = "tac_mvt_dsg_id";
+    public static final String tacTyCd = "tac_ty_cd";
+    public static final String tacUseCd = "tac_use_cd";
+    public static final String tacMajClmtId = "tac_maj_clmt_id";
+    public static final String tacBillActTxt = "tac_bill_act_txt";
+    public static final String tacCostCtrNm = "tac_cost_ctr_nm";
+    public static final String buic = "buic";
+    public static final String tacHistCd = "tac_hist_cd";
+    public static final String tacStatCd = "tac_stat_cd";
+    public static final String trnsprtnAcntTx = "trnsprtn_acnt_tx";
+    public static final String trnsprtnAcntBgnDt = "trnsprtn_acnt_bgn_dt";
+    public static final String trnsprtnAcntEndDt = "trnsprtn_acnt_end_dt";
+    public static final String ddActvtyAdrsId = "dd_actvty_adrs_id";
+    public static final String tacBlldAddFrstLnTx = "tac_blld_add_frst_ln_tx";
+    public static final String tacBlldAddScndLnTx = "tac_blld_add_scnd_ln_tx";
+    public static final String tacBlldAddThrdLnTx = "tac_blld_add_thrd_ln_tx";
+    public static final String tacBlldAddFrthLnTx = "tac_blld_add_frth_ln_tx";
+    public static final String tacFnctPocNm = "tac_fnct_poc_nm";
+    public static final String validLoaForTac = "valid_loa_for_tac";
+}

--- a/src/main/java/com/milmove/trdmlambda/milmove/service/DatabaseService.java
+++ b/src/main/java/com/milmove/trdmlambda/milmove/service/DatabaseService.java
@@ -6,21 +6,31 @@ import software.amazon.awssdk.services.rds.RdsClient;
 import software.amazon.awssdk.services.rds.RdsUtilities;
 import software.amazon.awssdk.services.rds.model.GenerateAuthenticationTokenRequest;
 
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.PreparedStatement;
+import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 import com.milmove.trdmlambda.milmove.model.LineOfAccounting;
 import com.milmove.trdmlambda.milmove.model.TransportationAccountingCode;
 import com.milmove.trdmlambda.milmove.util.SecretFetcher;
+import com.milmove.trdmlambda.milmove.constants.LinesOfAccountingDatabaseColumns;
+import com.milmove.trdmlambda.milmove.constants.TransportationAccountingCodesDatabaseColumns;
+
+import ch.qos.logback.classic.Logger;
 
 // README: https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/java-rds.html
 @Service
 public class DatabaseService {
+
+    private Logger logger = (Logger) LoggerFactory.getLogger(DatabaseService.class);
 
     private String hostname;
     private Integer port;
@@ -58,8 +68,70 @@ public class DatabaseService {
         return DriverManager.getConnection(jdbcUrl, username, authToken);
     }
 
+    // Batch update 10k TACs at a time
+    public void updateTransportationAccountingCodes(List<TransportationAccountingCode> codes) throws SQLException {
+        logger.info("updating Transportation Accounting Codes...");
+        logger.info("updating " + codes.size() + " TAC(s)...");
+        logger.info(codes.toString());
+
+
+        String sql = "UPDATE transportation_accounting_codes SET tac=?, loa_id=?, loa_sys_id=?, tac_fy_txt=?, tac_fn_bl_mod_cd=?, org_grp_dfas_cd=?, tac_mvt_dsg_id=?, tac_ty_cd=?, tac_use_cd=?, tac_maj_clmt_id=?, tac_bill_act_txt=?, tac_cost_ctr_nm=?, buic=?, tac_hist_cd=?, tac_stat_cd=?, trnsprtn_acnt_tx=?, trnsprtn_acnt_bgn_dt=?, trnsprtn_acnt_end_dt=?, dd_actvty_adrs_id=?, tac_blld_add_frst_ln_tx=?, tac_blld_add_scnd_ln_tx=?, tac_blld_add_thrd_ln_tx=?, tac_blld_add_frth_ln_tx=?, tac_fnct_poc_nm=? WHERE id=?";
+
+        Connection conn = this.getConnection();
+        conn.setAutoCommit(false);
+        
+        try (PreparedStatement pstmt = conn.prepareStatement(sql)) {
+
+            int count = 0;
+
+            for (TransportationAccountingCode code : codes) {
+
+                pstmt.setObject(1, code.getTac());
+                pstmt.setObject(2, code.getLoaID());
+                pstmt.setObject(3, code.getLoaSysID());
+                pstmt.setObject(4, code.getTacFyTxt());
+                pstmt.setObject(5, code.getTacFnBlModCd());
+                pstmt.setObject(6, code.getOrgGrpDfasCd());
+                pstmt.setObject(7, code.getTacMvtDsgID());
+                pstmt.setObject(8, code.getTacTyCd());
+                pstmt.setObject(9, code.getTacUseCd());
+                pstmt.setObject(10, code.getTacMajClmtID());
+                pstmt.setObject(11, code.getTacBillActTxt());
+                pstmt.setObject(12, code.getTacCostCtrNm());
+                pstmt.setObject(13, code.getBuic());
+                pstmt.setObject(14, code.getTacHistCd());
+                pstmt.setObject(15, code.getTacStatCd());
+                pstmt.setObject(16, code.getTrnsprtnAcntTx());
+                pstmt.setObject(17, code.getTrnsprtnAcntBgnDt());
+                pstmt.setObject(18, code.getTrnsprtnAcntEndDt());
+                pstmt.setObject(19, code.getDdActvtyAdrsID());
+                pstmt.setObject(20, code.getTacBlldAddFrstLnTx());
+                pstmt.setObject(21, code.getTacBlldAddScndLnTx());
+                pstmt.setObject(22, code.getTacBlldAddThrdLnTx());
+                pstmt.setObject(23, code.getTacBlldAddFrthLnTx());
+                pstmt.setObject(24, code.getTacFnctPocNm());
+                pstmt.setObject(25, code.getId());
+                pstmt.addBatch();
+
+                // Execute every 10000 rows or when finished with the provided TACs
+                if (count++ % 10000 == 0 || count == codes.size()) {
+                    pstmt.executeUpdate();
+                }
+            }
+            conn.commit();
+            logger.info("finished updating Transportation Accounting Codes...");
+
+            List<UUID> codeIds = codes.stream().map(loa -> loa.getId()).collect(Collectors.toList());
+            logger.info("updated the following TACs with Ids: \n" + codeIds.toString());
+        } catch (SQLException e) {
+            logger.info("failed updating Transportation Accounting Codes...");
+            conn.rollback();
+        }
+    }
+
     // Batch insert 10k TACs at a time
     public void insertTransportationAccountingCodes(List<TransportationAccountingCode> codes) throws SQLException {
+        logger.info("inserting Transportation Accounting Codes...");
 
         String sql = "INSERT INTO transportation_accounting_codes (id, tac, tac_sys_id, loa_sys_id, tac_fy_txt, tac_fn_bl_mod_cd, org_grp_dfas_cd, tac_mvt_dsg_id, tac_ty_cd, tac_use_cd, tac_maj_clmt_id, tac_bill_act_txt, tac_cost_ctr_nm, buic, tac_hist_cd, tac_stat_cd, trnsprtn_acnt_tx, trnsprtn_acnt_bgn_dt, trnsprtn_acnt_end_dt, dd_actvty_adrs_id, tac_blld_add_frst_ln_tx, tac_blld_add_scnd_ln_tx, tac_blld_add_thrd_ln_tx, tac_blld_add_frth_ln_tx, tac_fnct_poc_nm, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
 
@@ -105,11 +177,107 @@ public class DatabaseService {
                     pstmt.executeBatch();
                 }
             }
+            logger.info("finished inserting Transportation Accounting Codes...");
+        }
+    }
+
+    // Batch update 10k LOAs at a time
+    public void updateLinesOfAccountingCodes(List<LineOfAccounting> codes) throws SQLException {
+        logger.info("updating Lines of Accounting Codes...");
+
+        String sql = "UPDATE lines_of_accounting SET loa_dpt_id=?, loa_tnsfr_dpt_nm=?, loa_baf_id=?, loa_trsy_sfx_tx=?, loa_maj_clm_nm=?, loa_op_agncy_id=?, loa_allt_sn_id=?, loa_pgm_elmnt_id=?, loa_tsk_bdgt_sbln_tx=?, loa_df_agncy_alctn_rcpnt_id=?, loa_jb_ord_nm=?, loa_sbaltmt_rcpnt_id=?, loa_wk_cntr_rcpnt_nm=?, loa_maj_rmbsmt_src_id=?, loa_dtl_rmbsmt_src_id=?, loa_cust_nm=?, loa_obj_cls_id=?, loa_srv_src_id=?, loa_spcl_intr_id=?, loa_bdgt_acnt_cls_nm=?, loa_doc_id=?, loa_cls_ref_id=?, loa_instl_acntg_act_id=?, loa_lcl_instl_id=?, loa_fms_trnsactn_id=?, loa_dsc_tx=?,loa_bgn_dt=?, loa_end_dt=?, loa_fnct_prs_nm=?, loa_stat_cd=?, loa_hist_stat_cd=?, loa_hs_gds_cd=?, org_grp_dfas_cd=?, loa_uic=?, loa_trnsn_id=?, loa_sub_acnt_id=?, loa_bet_cd=?, loa_fnd_ty_fg_cd=?, loa_bgt_ln_itm_id=?, loa_scrty_coop_impl_agnc_cd=?, loa_scrty_coop_dsgntr_cd=?, loa_scrty_coop_ln_itm_id=?, loa_agnc_dsbr_cd=?, loa_agnc_acntng_cd=?, loa_fnd_cntr_id=?, loa_cst_cntr_id=?, loa_prj_id=?, loa_actvty_id=?, loa_cst_cd=?, loa_wrk_ord_id=?, loa_fncl_ar_id=?, loa_scrty_coop_cust_cd=?, loa_end_fy_tx=?, loa_bg_fy_tx=?, loa_bgt_rstr_cd=?, loa_bgt_sub_act_cd=? WHERE id=?";
+
+        Connection conn = this.getConnection();
+        conn.setAutoCommit(false);
+
+        try (PreparedStatement pstmt = conn.prepareStatement(sql)) {
+
+            int count = 0;
+
+            for (LineOfAccounting code : codes) {
+
+                pstmt.setObject(1, code.getLoaDptID());
+                pstmt.setObject(2, code.getLoaTnsfrDptNm());
+                pstmt.setObject(3, code.getLoaBafID());
+                pstmt.setObject(4, code.getLoaTrsySfxTx());
+                pstmt.setObject(5, code.getLoaMajClmNm());
+                pstmt.setObject(6, code.getLoaOpAgncyID());
+                pstmt.setObject(7, code.getLoaAlltSnID());
+                pstmt.setObject(8, code.getLoaPgmElmntID());
+                pstmt.setObject(9, code.getLoaTskBdgtSblnTx());
+                pstmt.setObject(10, code.getLoaDfAgncyAlctnRcpntID());
+                pstmt.setObject(11, code.getLoaJbOrdNm());
+                pstmt.setObject(12, code.getLoaSbaltmtRcpntID());
+                pstmt.setObject(13, code.getLoaWkCntrRcpntNm());
+                pstmt.setObject(14, code.getLoaMajRmbsmtSrcID());
+                pstmt.setObject(15, code.getLoaDtlRmbsmtSrcID());
+                pstmt.setObject(16, code.getLoaCustNm());
+                pstmt.setObject(17, code.getLoaObjClsID());
+                pstmt.setObject(18, code.getLoaSrvSrcID());
+                pstmt.setObject(19, code.getLoaSpclIntrID());
+                pstmt.setObject(20, code.getLoaBdgtAcntClsNm());
+                pstmt.setObject(21, code.getLoaDocID());
+                pstmt.setObject(22, code.getLoaClsRefID());
+                pstmt.setObject(23, code.getLoaInstlAcntgActID());
+                pstmt.setObject(24, code.getLoaLclInstlID());
+                pstmt.setObject(25, code.getLoaFmsTrnsactnID());
+                pstmt.setObject(26, code.getLoaDscTx());
+                pstmt.setObject(27, code.getLoaBgnDt());
+                pstmt.setObject(28, code.getLoaEndDt());
+                pstmt.setObject(29, code.getLoaFnctPrsNm());
+                pstmt.setObject(30, code.getLoaStatCd());
+                pstmt.setObject(31, code.getLoaHistStatCd());
+                pstmt.setObject(32, code.getLoaHsGdsCd());
+                pstmt.setObject(33, code.getOrgGrpDfasCd());
+                pstmt.setObject(34, code.getLoaUic());
+                pstmt.setObject(35, code.getLoaTrnsnID());
+                pstmt.setObject(36, code.getLoaSubAcntID());
+                pstmt.setObject(37, code.getLoaBetCd());
+                pstmt.setObject(38, code.getLoaFndTyFgCd());
+                pstmt.setObject(39, code.getLoaBgtLnItmID());
+                pstmt.setObject(40, code.getLoaScrtyCoopImplAgncCd());
+                pstmt.setObject(41, code.getLoaScrtyCoopDsgntrCd());
+                pstmt.setObject(42, code.getLoaScrtyCoopLnItmID());
+                pstmt.setObject(43, code.getLoaAgncDsbrCd());
+                pstmt.setObject(44, code.getLoaAgncAcntngCd());
+                pstmt.setObject(45, code.getLoaFndCntrID());
+                pstmt.setObject(46, code.getLoaCstCntrID());
+                pstmt.setObject(47, code.getLoaPrjID());
+                pstmt.setObject(48, code.getLoaActvtyID());
+                pstmt.setObject(49, code.getLoaCstCd());
+                pstmt.setObject(50, code.getLoaWrkOrdID());
+                pstmt.setObject(51, code.getLoaFnclArID());
+                pstmt.setObject(52, code.getLoaScrtyCoopCustCd());
+                pstmt.setObject(53, code.getLoaEndFyTx());
+                pstmt.setObject(54, code.getLoaBgFyTx());
+                pstmt.setObject(55, code.getLoaBgtRstrCd());
+                pstmt.setObject(56, code.getLoaBgtSubActCd());
+                pstmt.setObject(57, code.getId());
+
+                pstmt.addBatch();
+
+                // Execute every 10000 rows or when finished with the provided LOAs
+                if (count++ % 10000 == 0 || count == codes.size()) {
+                    pstmt.executeUpdate();
+                }
+            }
+            conn.commit();
+
+            logger.info("finished updating Lines of Accounting Codes...");
+
+            List<UUID> codeIds = codes.stream().map(loa -> loa.getId()).collect(Collectors.toList());
+            logger.info("updated the following TACs with Id: \n" + codeIds.toString());
+        } catch (SQLException ex) {
+            logger.info("failed to update Lines of Accounting Codes...");
+            // Roll back update if fails
+            conn.rollback();
         }
     }
 
     // Batch insert 10k LOAs at a time
     public void insertLinesOfAccounting(List<LineOfAccounting> loas) throws SQLException {
+
+        logger.info("inserting Line of Accounting Codes...");
 
         String sql = "INSERT INTO lines_of_accounting (id, loa_sys_id, loa_dpt_id, loa_tnsfr_dpt_nm, loa_baf_id, loa_trsy_sfx_tx, loa_maj_clm_nm, loa_op_agncy_id, loa_allt_sn_id, loa_pgm_elmnt_id, loa_tsk_bdgt_sbln_tx, loa_df_agncy_alctn_rcpnt_id, loa_jb_ord_nm, loa_sbaltmt_rcpnt_id, loa_wk_cntr_rcpnt_nm, loa_maj_rmbsmt_src_id, loa_dtl_rmbsmt_src_id, loa_cust_nm, loa_obj_cls_id, loa_srv_src_id, loa_spcl_intr_id, loa_bdgt_acnt_cls_nm, loa_doc_id, loa_cls_ref_id, loa_instl_acntg_act_id, loa_lcl_instl_id, loa_fms_trnsactn_id, loa_dsc_tx, loa_bgn_dt, loa_end_dt, loa_fnct_prs_nm, loa_stat_cd, loa_hist_stat_cd, loa_hs_gds_cd, org_grp_dfas_cd, loa_uic, loa_trnsn_id, loa_sub_acnt_id, loa_bet_cd, loa_fnd_ty_fg_cd, loa_bgt_ln_itm_id, loa_scrty_coop_impl_agnc_cd, loa_scrty_coop_dsgntr_cd, loa_scrty_coop_ln_itm_id, loa_agnc_dsbr_cd, loa_agnc_acntng_cd, loa_fnd_cntr_id, loa_cst_cntr_id, loa_prj_id, loa_actvty_id, loa_cst_cd, loa_wrk_ord_id, loa_fncl_ar_id, loa_scrty_coop_cust_cd, loa_end_fy_tx, loa_bg_fy_tx, loa_bgt_rstr_cd, loa_bgt_sub_act_cd, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
 
@@ -188,7 +356,178 @@ public class DatabaseService {
                     pstmt.executeBatch();
                 }
             }
+            logger.info("finished inserting Line of Accounting Codes...");
         }
     }
 
+    public ArrayList<LineOfAccounting> getAllLoas() throws SQLException {
+
+        logger.info("retrieving all LOAs");
+
+        ArrayList<LineOfAccounting> loas;
+
+        // Select all loas
+        String sql = "SELECT * FROM lines_of_accounting";
+
+        try (Connection conn = this.getConnection(); PreparedStatement pstmt = conn.prepareStatement(sql);) {
+            ResultSet rs = pstmt.executeQuery();
+            loas = dbLoasToModel(rs);
+        }
+
+        logger.info("finished retrieving all LOAs");
+        return loas;
+    }
+
+    public void deleteDuplicateLoas() throws SQLException {
+
+        logger.info(
+                "deleting LOAs with no unique loa_sys_id and not referenced in the transportation_accounting_codes table");
+
+        // Select all loas
+        String sql = "Delete From lines_of_accounting Where id in (Select id From lines_of_accounting Where loa_sys_id in (SELECT loa_sys_id FROM lines_of_accounting GROUP BY loa_sys_id HAVING COUNT(*) > 1) AND id NOT IN (SELECT loa_id FROM transportation_accounting_codes where loa_id is not NULL))";
+
+        try (Connection conn = this.getConnection(); PreparedStatement pstmt = conn.prepareStatement(sql);) {
+            pstmt.execute();
+        }
+
+        logger.info("finished deleting LOAs");
+    }
+
+    public ArrayList<LineOfAccounting> dbLoasToModel(ResultSet rs) throws SQLException {
+
+        ArrayList<LineOfAccounting> loas = new ArrayList<LineOfAccounting>();
+
+        while (rs.next()) {
+            LineOfAccounting loa = new LineOfAccounting();
+            loa.setId(UUID.fromString(rs.getString(LinesOfAccountingDatabaseColumns.id)));
+            loa.setLoaSysID(rs.getString(LinesOfAccountingDatabaseColumns.loaSysId));
+            loa.setLoaDptID(rs.getString(LinesOfAccountingDatabaseColumns.loaDptId));
+            loa.setLoaTnsfrDptNm(rs.getString(LinesOfAccountingDatabaseColumns.loaTnsfrDptNm));
+            loa.setLoaBafID(rs.getString(LinesOfAccountingDatabaseColumns.loaBafId));
+            loa.setLoaTrsySfxTx(rs.getString(LinesOfAccountingDatabaseColumns.loaTrsySfxTx));
+            loa.setLoaMajClmNm(rs.getString(LinesOfAccountingDatabaseColumns.loaMajClmNm));
+            loa.setLoaOpAgncyID(rs.getString(LinesOfAccountingDatabaseColumns.loaOpAgncy_id));
+            loa.setLoaAlltSnID(rs.getString(LinesOfAccountingDatabaseColumns.loaAlltSnId));
+            loa.setLoaPgmElmntID(rs.getString(LinesOfAccountingDatabaseColumns.loaPgmElmntId));
+            loa.setLoaTskBdgtSblnTx(rs.getString(LinesOfAccountingDatabaseColumns.loaTskBdgtSblnTx));
+            loa.setLoaDfAgncyAlctnRcpntID(rs.getString(LinesOfAccountingDatabaseColumns.loaDfAgncyAlctnRcpntId));
+            loa.setLoaJbOrdNm(rs.getString(LinesOfAccountingDatabaseColumns.loaJbOrdNm));
+            loa.setLoaSbaltmtRcpntID(rs.getString(LinesOfAccountingDatabaseColumns.loaSbaltmtRcpntId));
+            loa.setLoaWkCntrRcpntNm(rs.getString(LinesOfAccountingDatabaseColumns.loaWkCntrRcpntNm));
+            loa.setLoaMajRmbsmtSrcID(rs.getString(LinesOfAccountingDatabaseColumns.loaMajRmbsmtSrcId));
+            loa.setLoaDtlRmbsmtSrcID(rs.getString(LinesOfAccountingDatabaseColumns.loaDtlRmbsmtSrcId));
+            loa.setLoaCustNm(rs.getString(LinesOfAccountingDatabaseColumns.loaCustNm));
+            loa.setLoaObjClsID(rs.getString(LinesOfAccountingDatabaseColumns.loaObjClsId));
+            loa.setLoaSrvSrcID(rs.getString(LinesOfAccountingDatabaseColumns.loaSrvSrcId));
+            loa.setLoaSpclIntrID(rs.getString(LinesOfAccountingDatabaseColumns.loaSpclIntrId));
+            loa.setLoaBdgtAcntClsNm(rs.getString(LinesOfAccountingDatabaseColumns.loaBdgtAcntClsNm));
+            loa.setLoaDocID(rs.getString(LinesOfAccountingDatabaseColumns.loaDocId));
+            loa.setLoaClsRefID(rs.getString(LinesOfAccountingDatabaseColumns.loaClsRefId));
+            loa.setLoaInstlAcntgActID(rs.getString(LinesOfAccountingDatabaseColumns.loaInstlAcntgActId));
+            loa.setLoaLclInstlID(rs.getString(LinesOfAccountingDatabaseColumns.loaLclInstlId));
+            loa.setLoaFmsTrnsactnID(rs.getString(LinesOfAccountingDatabaseColumns.loaFmsTrnsactnId));
+            loa.setLoaDscTx(rs.getString(LinesOfAccountingDatabaseColumns.loaDscTx));
+            loa.setLoaFnctPrsNm(rs.getString(LinesOfAccountingDatabaseColumns.loaFnctPrsNm));
+            loa.setLoaStatCd(rs.getString(LinesOfAccountingDatabaseColumns.loaStatCd));
+            loa.setLoaHistStatCd(rs.getString(LinesOfAccountingDatabaseColumns.loaHistStatCd));
+            loa.setLoaHsGdsCd(rs.getString(LinesOfAccountingDatabaseColumns.loaHsGdsCd));
+            loa.setOrgGrpDfasCd(rs.getString(LinesOfAccountingDatabaseColumns.orgGrpDfasCd));
+            loa.setLoaUic(rs.getString(LinesOfAccountingDatabaseColumns.loaUic));
+            loa.setLoaTrnsnID(rs.getString(LinesOfAccountingDatabaseColumns.loaTrnsnId));
+            loa.setLoaSubAcntID(rs.getString(LinesOfAccountingDatabaseColumns.loaSubAcntId));
+            loa.setLoaBetCd(rs.getString(LinesOfAccountingDatabaseColumns.loaBetCd));
+            loa.setLoaFndTyFgCd(rs.getString(LinesOfAccountingDatabaseColumns.loaFndTyFgCd));
+            loa.setLoaBgtLnItmID(rs.getString(LinesOfAccountingDatabaseColumns.loaBgtLnItmId));
+            loa.setLoaScrtyCoopImplAgncCd(rs.getString(LinesOfAccountingDatabaseColumns.loaScrtyCoopImplAgncCd));
+            loa.setLoaScrtyCoopDsgntrCd(rs.getString(LinesOfAccountingDatabaseColumns.loaScrtyCoopDsgntrCd));
+            loa.setLoaScrtyCoopLnItmID(rs.getString(LinesOfAccountingDatabaseColumns.loaScrtyCoopLnItmId));
+            loa.setLoaAgncDsbrCd(rs.getString(LinesOfAccountingDatabaseColumns.loaAgncDsbrCd));
+            loa.setLoaAgncAcntngCd(rs.getString(LinesOfAccountingDatabaseColumns.loaAgncAcntngCd));
+            loa.setLoaFndCntrID(rs.getString(LinesOfAccountingDatabaseColumns.loaFndCntrId));
+            loa.setLoaCstCntrID(rs.getString(LinesOfAccountingDatabaseColumns.loaCstCntrId));
+            loa.setLoaPrjID(rs.getString(LinesOfAccountingDatabaseColumns.loaPrjId));
+            loa.setLoaActvtyID(rs.getString(LinesOfAccountingDatabaseColumns.loaActvtyId));
+            loa.setLoaCstCd(rs.getString(LinesOfAccountingDatabaseColumns.loaCstCd));
+            loa.setLoaWrkOrdID(rs.getString(LinesOfAccountingDatabaseColumns.loaWrkOrdId));
+            loa.setLoaFnclArID(rs.getString(LinesOfAccountingDatabaseColumns.loaFnclArId));
+            loa.setLoaScrtyCoopCustCd(rs.getString(LinesOfAccountingDatabaseColumns.loaScrtyCoopCustCd));
+            loa.setLoaEndFyTx(Integer.valueOf(rs.getString(LinesOfAccountingDatabaseColumns.loaEndFyTx)));
+            loa.setLoaBgFyTx(Integer.valueOf(rs.getString(LinesOfAccountingDatabaseColumns.loaBgFyTx)));
+            loa.setLoaBgtRstrCd(rs.getString(LinesOfAccountingDatabaseColumns.loaBgtRstrCd));
+            loa.setLoaBgtSubActCd(rs.getString(LinesOfAccountingDatabaseColumns.loaBgtSubActCd));
+            loas.add(loa);
+        }
+
+        return loas;
+    }
+
+    public ArrayList<TransportationAccountingCode> getAllTacs() throws SQLException {
+
+        logger.info("retrieving all TACs");
+
+        ArrayList<TransportationAccountingCode> tacs = new ArrayList<TransportationAccountingCode>();
+
+        // Select all TACs
+        String sql = "SELECT * FROM transportation_accounting_codes;";
+
+        try (Connection conn = this.getConnection(); PreparedStatement pstmt = conn.prepareStatement(sql)) {
+            ResultSet rs = pstmt.executeQuery();
+            while (rs.next()) {
+                TransportationAccountingCode tac = new TransportationAccountingCode();
+                tac.setId(UUID.fromString(rs.getString(TransportationAccountingCodesDatabaseColumns.id)));
+                tac.setTacSysID(rs.getString(TransportationAccountingCodesDatabaseColumns.tacSysId));
+                tac.setLoaSysID(rs.getString(TransportationAccountingCodesDatabaseColumns.loaSysId));
+                tac.setTac(rs.getString(TransportationAccountingCodesDatabaseColumns.tac));
+                tac.setTacFyTxt(rs.getString(TransportationAccountingCodesDatabaseColumns.tacFnBlModCd));
+                tac.setTacFnBlModCd(rs.getString(TransportationAccountingCodesDatabaseColumns.tacFnBlModCd));
+                tac.setOrgGrpDfasCd(rs.getString(TransportationAccountingCodesDatabaseColumns.orgGrpDfasCd));
+                tac.setTacTyCd(rs.getString(TransportationAccountingCodesDatabaseColumns.tacTyCd));
+                tac.setTacUseCd(rs.getString(TransportationAccountingCodesDatabaseColumns.tacUseCd));
+                tac.setTacMajClmtID(rs.getString(TransportationAccountingCodesDatabaseColumns.tacMajClmtId));
+                tac.setTacCostCtrNm(rs.getString(TransportationAccountingCodesDatabaseColumns.tacCostCtrNm));
+                tac.setTacStatCd(rs.getString(TransportationAccountingCodesDatabaseColumns.tacStatCd));
+                tac.setTrnsprtnAcntTx(rs.getString(TransportationAccountingCodesDatabaseColumns.trnsprtnAcntTx));
+                tac.setDdActvtyAdrsID(rs.getString(TransportationAccountingCodesDatabaseColumns.ddActvtyAdrsId));
+                tac.setTacBlldAddFrstLnTx(
+                        rs.getString(TransportationAccountingCodesDatabaseColumns.tacBlldAddFrstLnTx));
+                tac.setTacBlldAddScndLnTx(
+                        rs.getString(TransportationAccountingCodesDatabaseColumns.tacBlldAddScndLnTx));
+                tac.setTacBlldAddThrdLnTx(
+                        rs.getString(TransportationAccountingCodesDatabaseColumns.tacBlldAddThrdLnTx));
+                tac.setTacBlldAddFrthLnTx(
+                        rs.getString(TransportationAccountingCodesDatabaseColumns.tacBlldAddFrthLnTx));
+                tac.setTacFnctPocNm(rs.getString(TransportationAccountingCodesDatabaseColumns.tacFnctPocNm));
+                tac.setTacMvtDsgID(rs.getString(TransportationAccountingCodesDatabaseColumns.tacMvtDsgId));
+                tac.setTacBillActTxt(rs.getString(TransportationAccountingCodesDatabaseColumns.tacBillActTxt));
+                tac.setBuic(rs.getString(TransportationAccountingCodesDatabaseColumns.buic));
+                tac.setTacHistCd(rs.getString(TransportationAccountingCodesDatabaseColumns.tacHistCd));
+
+                tacs.add(tac);
+            }
+
+            logger.info("finished retrieving all TACs");
+            return tacs;
+        }
+
+    }
+
+    // Identify duplicate LOA.loaSysIds
+    public ArrayList<LineOfAccounting> getDuplicateLoasToDelete() throws SQLException {
+
+        logger.info(
+                "identifying LOAs to delete based on loa records with a non unique loa_sys_id and not referenced in the transportation_accounting_codes table");
+
+        // Select all duplicate loa_sys_id
+        String sql = "Select * From lines_of_accounting Where loa_sys_id in (SELECT loa_sys_id FROM lines_of_accounting GROUP BY loa_sys_id HAVING COUNT(*) > 1) AND id NOT IN (SELECT loa_id FROM transportation_accounting_codes WHERE loa_id is NOT NULL)";
+
+        try (Connection conn = this.getConnection(); PreparedStatement pstmt = conn.prepareStatement(sql)) {
+            ResultSet rs = pstmt.executeQuery();
+
+            ArrayList<LineOfAccounting> loas;
+            loas = dbLoasToModel(rs);
+
+            logger.info("finished identifying LOAs to delete");
+            return loas;
+        }
+    }
 }

--- a/src/test/java/com/milmove/trdmlambda/milmove/util/DatabaseServiceTest.java
+++ b/src/test/java/com/milmove/trdmlambda/milmove/util/DatabaseServiceTest.java
@@ -1,0 +1,459 @@
+package com.milmove.trdmlambda.milmove.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.milmove.trdmlambda.milmove.model.LineOfAccounting;
+import com.milmove.trdmlambda.milmove.model.TransportationAccountingCode;
+import com.milmove.trdmlambda.milmove.service.DatabaseService;
+
+@ExtendWith(MockitoExtension.class)
+public class DatabaseServiceTest {
+
+    final String testDbUrl = System.getenv("TEST_DB_URL");
+
+    public DatabaseService spyDatabaseService;
+    public Connection testDbConn;
+
+    public Connection createTestDbConnection() throws SQLException {
+        Connection conn = DriverManager.getConnection(testDbUrl);
+        return conn;
+    }
+
+    void setUpTests() throws SQLException {
+        SecretFetcher mockSeceretFetcher = mock(SecretFetcher.class);
+        when(mockSeceretFetcher.getSecret("rds_hostname")).thenReturn(System.getenv("TEST_DB_HOST"));
+        when(mockSeceretFetcher.getSecret("rds_port")).thenReturn(System.getenv("TEST_DB_PORT"));
+        when(mockSeceretFetcher.getSecret("rds_db_name")).thenReturn(System.getenv("TEST_DB_NAME"));
+        when(mockSeceretFetcher.getSecret("rds_username")).thenReturn(System.getenv("TEST_DB_USER"));
+        DatabaseService databaseService = new DatabaseService(mockSeceretFetcher);
+        spyDatabaseService = spy(databaseService);
+
+        // Create test_db connection
+        testDbConn = DriverManager.getConnection(testDbUrl);
+
+        // Mock the DatabaseService.getConnection() to return the test_db connection
+        doReturn(testDbConn).when(spyDatabaseService).getConnection();
+
+        // Make sure the test_db connection is returned when .getConnection is called
+        assertEquals(testDbConn, spyDatabaseService.getConnection());
+    }
+
+    // TESTS
+    @Test // Test that we can identify duplicate LOA codes from a list of LOAS
+    void deleteDuplicateLoasTest() throws SQLException {
+
+        SecretFetcher mockSeceretFetcher = mock(SecretFetcher.class);
+        when(mockSeceretFetcher.getSecret("rds_hostname")).thenReturn(System.getenv("TEST_DB_HOST"));
+        when(mockSeceretFetcher.getSecret("rds_port")).thenReturn(System.getenv("TEST_DB_PORT"));
+        when(mockSeceretFetcher.getSecret("rds_db_name")).thenReturn(System.getenv("TEST_DB_NAME"));
+        when(mockSeceretFetcher.getSecret("rds_username")).thenReturn(System.getenv("TEST_DB_USER"));
+        DatabaseService databaseService = new DatabaseService(mockSeceretFetcher);
+        spyDatabaseService = spy(databaseService);
+
+        // Create test_db connection
+        testDbConn = DriverManager.getConnection(testDbUrl);
+
+        // Mock the DatabaseService.getConnection() to return the test_db connection
+        doReturn(testDbConn).when(spyDatabaseService).getConnection();
+
+        // Make sure the test_db connection is returned when .getConnection is called
+        assertEquals(testDbConn, spyDatabaseService.getConnection());
+
+        ArrayList<LineOfAccounting> loas = spyDatabaseService.getAllLoas();
+
+        Connection conn2 = createTestDbConnection();
+
+        // Mock the DatabaseService.getConnection() to return the test_db connection
+        doReturn(conn2).when(spyDatabaseService).getConnection();
+
+        // Make sure the test_db connection is returned when .getConnection is called
+        assertEquals(conn2, spyDatabaseService.getConnection());
+
+        ArrayList<TransportationAccountingCode> tacs = spyDatabaseService.getAllTacs();
+
+        assertTrue(loas.size() > 0);
+        assertTrue(tacs.size() > 0);
+
+        Connection conn3 = createTestDbConnection();
+
+        // Mock the DatabaseService.getConnection() to return the test_db connection
+        doReturn(conn3).when(spyDatabaseService).getConnection();
+
+        // Make sure the test_db connection is returned when .getConnection is called
+        assertEquals(conn3, spyDatabaseService.getConnection());
+
+        ArrayList<LineOfAccounting> unneededLoas = spyDatabaseService.getDuplicateLoasToDelete();
+
+        Connection conn4 = createTestDbConnection();
+
+        // Mock the DatabaseService.getConnection() to return the test_db connection
+        doReturn(conn4).when(spyDatabaseService).getConnection();
+
+        // Make sure the test_db connection is returned when .getConnection is called
+        assertEquals(conn4, spyDatabaseService.getConnection());
+
+        spyDatabaseService.deleteDuplicateLoas();
+
+        Connection conn5 = createTestDbConnection();
+
+        // Mock the DatabaseService.getConnection() to return the test_db connection
+        doReturn(conn5).when(spyDatabaseService).getConnection();
+
+        ArrayList<LineOfAccounting> loasAfterDelete = spyDatabaseService.getAllLoas();
+
+        assertTrue(loasAfterDelete.size() == loas.size() - unneededLoas.size());
+    }
+
+    @Test // Test that we can retrieve all LOA codes from database table
+          // line_of_accounting
+    void getAllLoasTest() throws SQLException {
+        setUpTests();
+        ArrayList<LineOfAccounting> loas = spyDatabaseService.getAllLoas();
+        assertTrue(loas.size() > 0);
+    }
+
+    @Test // Test that we can retrieve all TAC codes from database table
+          // transportation_accounting_codes
+    void getAllTacsTest() throws Exception {
+        setUpTests();
+        ArrayList<TransportationAccountingCode> tacs = spyDatabaseService.getAllTacs();
+        assertTrue(tacs.size() > 0);
+    }
+
+    // Test that we can insert LOA(s) using
+    // DatabaseService.insertLinesOfAccounting()
+    @Test
+    void testInsertLinesOfAccounting() throws Exception {
+        setUpTests();
+
+        // Create mock loas for test
+        ArrayList<LineOfAccounting> testLoas = createMockLoas(1);
+
+        // Invoke insertLinesOfAccounting() with test TAC(s)
+        spyDatabaseService.insertLinesOfAccounting(testLoas);
+
+        // Verfiy test LOAs made it to the test_db
+        try {
+            // Select the LOA record with the UUID added through invoking
+            // spyDatabaseService.insertLinesOfAccounting(testLoas)
+            String sql = "select * from lines_of_accounting where id= ?";
+
+            Connection conn = DriverManager.getConnection(testDbUrl);
+
+            if (conn != null) {
+                PreparedStatement pstmt = conn.prepareStatement(sql);
+                pstmt.setObject(1, testLoas.get(0).getId());
+
+                ResultSet rs = pstmt.executeQuery();
+
+                String uuid = "";
+                if (rs.next()) {
+                    uuid = rs.getString("id");
+                }
+
+                // Verify the UUIDs match to prove a successful insert using
+                // insertLinesOfAccounting()
+                assertEquals(UUID.fromString(uuid), testLoas.get(0).getId());
+                conn.close();
+            }
+        } catch (Exception e) {
+            System.out.println("Database connection error to test_db");
+            System.out.println(e);
+        }
+    }
+
+    // Test that we can update existing LOA(s) using
+    // DatabaseService.updateLinesOfAccountingCodes()
+    @Test
+    void testUpdateLinesOfAccountingCodes() throws Exception {
+
+        setUpTests();
+
+        // Create a list of TAC(s)
+        List<LineOfAccounting> testLoas = createMockLoas(2);
+        testLoas.get(0).setLoaSysID("PENDING_UPDATE");
+        testLoas.get(0).setLoaDptID("01");
+        testLoas.get(1).setLoaSysID("PENDING_UPDATE2");
+        testLoas.get(1).setLoaDptID("02");
+
+        // Invoke insertLinesOfAccounting() with test LOA(s)
+        spyDatabaseService.insertLinesOfAccounting(testLoas);
+
+        // Create a list of LOA(s)
+        List<LineOfAccounting> testLoas2 = testLoas;
+        testLoas2.get(0).setLoaSysID("PENDING_UPDATE");
+        testLoas2.get(0).setLoaDptID("03");
+        testLoas2.get(1).setLoaSysID("PENDING_UPDATE");
+        testLoas2.get(1).setLoaDptID("04");
+
+        Connection conn1 = createTestDbConnection();
+
+        // Mock the DatabaseService.getConnection() to return the test_db connection
+        doReturn(conn1).when(spyDatabaseService).getConnection();
+
+        // Make sure the test_db connection is returned when .getConnection is called
+        assertEquals(conn1, spyDatabaseService.getConnection());
+
+        // Update TAC Codes
+        spyDatabaseService.updateLinesOfAccountingCodes(testLoas2);
+
+        Connection conn2 = createTestDbConnection();
+
+        // Mock the DatabaseService.getConnection() to return the test_db connection
+        doReturn(conn2).when(spyDatabaseService).getConnection();
+
+        // Make sure the test_db connection is returned when .getConnection is called
+        assertEquals(conn2, spyDatabaseService.getConnection());
+
+        ArrayList<LineOfAccounting> dbTacs = spyDatabaseService.getAllLoas();
+
+        List<LineOfAccounting> codes = dbTacs.stream().filter(tac -> tac.getId().equals(testLoas.get(0).getId()))
+                .collect(Collectors.toList());
+
+        assertEquals("03", codes.get(0).getLoaDptID());
+
+    }
+
+    // Test that we can insert TAC codes using
+    // DatabaseService.insertTransportationAccountingCodes()
+    @Test
+    void testInsertTransportationAccountingCodes() throws Exception {
+        setUpTests();
+
+        // Create a list of TAC(s)
+        List<TransportationAccountingCode> testTacs = createMockTacs(1);
+
+        // Invoke insertTransportationAccountingCodes() with test TAC(s)
+        spyDatabaseService.insertTransportationAccountingCodes(testTacs);
+
+        // Verfiy test TAC(s) made it to the test_db
+        try {
+            // Select the TAC record with the UUID added through invoking
+            spyDatabaseService.insertTransportationAccountingCodes(testTacs);
+            String sql = "select * from transportation_accounting_codes where id= ?";
+
+            Connection conn = DriverManager.getConnection(testDbUrl);
+
+            if (conn != null) {
+                PreparedStatement pstmt = conn.prepareStatement(sql);
+                pstmt.setObject(1, testTacs.get(0).getId());
+
+                ResultSet rs = pstmt.executeQuery();
+
+                String uuid = "";
+                if (rs.next()) {
+                    uuid = rs.getString("id");
+                }
+
+                // Verify the UUIDs match to prove a successful insert using
+                assertEquals(UUID.fromString(uuid), testTacs.get(0).getId());
+                conn.close();
+            }
+
+        } catch (Exception e) {
+            System.out.println("Database connection error to test_db");
+            System.out.println(e);
+        }
+    }
+
+    // Test that we can update existing TAC(s) using
+    // DatabaseService.updateTransportationAccountingCodes()
+    @Test
+    void testUpdateTransportationAccountingCodes() throws Exception {
+
+        setUpTests();
+
+        // Create a list of TAC(s)
+        List<TransportationAccountingCode> testTacs = createMockTacs(2);
+        testTacs.get(0).setTacSysID("PENDING_UPDATE");
+        testTacs.get(0).setTac("2222");
+        testTacs.get(1).setTacSysID("PENDING_UPDATE2");
+        testTacs.get(1).setTac("3333");
+
+        // Invoke insertTransportationAccountingCodes() with test TAC(s)
+        spyDatabaseService.insertTransportationAccountingCodes(testTacs);
+
+        // Create a list of TAC(s)
+        List<TransportationAccountingCode> testTacs2 = testTacs;
+        testTacs2.get(0).setTacSysID("PENDING_UPDATE");
+        testTacs2.get(0).setTac("4445");
+        testTacs2.get(1).setTacSysID("PENDING_UPDATE");
+        testTacs2.get(1).setTac("6667");
+
+        Connection conn1 = createTestDbConnection();
+
+        // Mock the DatabaseService.getConnection() to return the test_db connection
+        doReturn(conn1).when(spyDatabaseService).getConnection();
+
+        // Make sure the test_db connection is returned when .getConnection is called
+        assertEquals(conn1, spyDatabaseService.getConnection());
+
+        // Update TAC Codes
+        spyDatabaseService.updateTransportationAccountingCodes(testTacs2);
+
+        Connection conn2 = createTestDbConnection();
+
+        // Mock the DatabaseService.getConnection() to return the test_db connection
+        doReturn(conn2).when(spyDatabaseService).getConnection();
+
+        // Make sure the test_db connection is returned when .getConnection is called
+        assertEquals(conn2, spyDatabaseService.getConnection());
+
+        ArrayList<TransportationAccountingCode> dbTacs = spyDatabaseService.getAllTacs();
+
+        List<TransportationAccountingCode> codes = dbTacs.stream()
+                .filter(tac -> tac.getId().equals(testTacs.get(0).getId())).collect(Collectors.toList());
+
+        assertEquals(testTacs.get(0).getTac(), codes.get(0).getTac());
+    }
+
+    // TEST HELPER FUNCTIONS
+
+    // Create mock loas
+    public ArrayList<LineOfAccounting> createMockLoas(int amount) {
+        ArrayList<LineOfAccounting> mockLoas = new ArrayList<LineOfAccounting>();
+
+        for (int index = 0; index != amount; index++) {
+            LineOfAccounting mockLoa = createMockLoa();
+            mockLoas.add(mockLoa);
+        }
+
+        return mockLoas;
+    }
+
+    // Create a mock loa
+    public LineOfAccounting createMockLoa() {
+        LineOfAccounting mockLoa = new LineOfAccounting();
+
+        UUID testUUID = UUID.randomUUID();
+
+        mockLoa.setId(testUUID);
+        mockLoa.setLoaSysID("TESTFAKE");
+        mockLoa.setLoaDptID("1");
+        mockLoa.setLoaTnsfrDptNm("0000");
+        mockLoa.setLoaBafID("0000");
+        mockLoa.setLoaTrsySfxTx("0000");
+        mockLoa.setLoaMajClmNm("0000");
+        mockLoa.setLoaOpAgncyID("1A");
+        mockLoa.setLoaAlltSnID("123A");
+        mockLoa.setLoaPgmElmntID("00000000");
+        mockLoa.setLoaTskBdgtSblnTx("00000000");
+        mockLoa.setLoaDfAgncyAlctnRcpntID("0000");
+        mockLoa.setLoaJbOrdNm("T");
+        mockLoa.setLoaSbaltmtRcpntID("A");
+        mockLoa.setLoaWkCntrRcpntNm("000000");
+        mockLoa.setLoaMajRmbsmtSrcID("I");
+        mockLoa.setLoaDtlRmbsmtSrcID("000");
+        mockLoa.setLoaCustNm("000000");
+        mockLoa.setLoaObjClsID("22NL");
+        mockLoa.setLoaSrvSrcID("A");
+        mockLoa.setLoaSpclIntrID("A");
+        mockLoa.setLoaBdgtAcntClsNm("00000000");
+        mockLoa.setLoaDocID("HHG12345678900");
+        mockLoa.setLoaLclInstlID("000000000000000000");
+        mockLoa.setLoaFmsTrnsactnID("000000000000");
+        mockLoa.setLoaDscTx("PERSONAL PROPERTY - FAKE DATA DIVISION");
+        mockLoa.setLoaEndDt(LocalDateTime.now());
+        mockLoa.setLoaBgnDt(LocalDateTime.now());
+        mockLoa.setLoaFnctPrsNm("0000");
+        mockLoa.setLoaStatCd("U");
+        mockLoa.setLoaHistStatCd("A");
+        mockLoa.setLoaHsGdsCd("HC");
+        mockLoa.setOrgGrpDfasCd("ZZ");
+        mockLoa.setLoaUic("test");
+        mockLoa.setLoaTrnsnID("C11");
+        mockLoa.setLoaSubAcntID("A");
+        mockLoa.setLoaBetCd("A");
+        mockLoa.setLoaFndTyFgCd("A");
+        mockLoa.setLoaBgtLnItmID("00000000");
+        mockLoa.setLoaScrtyCoopImplAgncCd("A");
+        mockLoa.setLoaScrtyCoopDsgntrCd("0000");
+        mockLoa.setLoaScrtyCoopLnItmID("000");
+        mockLoa.setLoaAgncDsbrCd("A");
+        mockLoa.setLoaAgncAcntngCd("A");
+        mockLoa.setLoaFndCntrID("000000000000");
+        mockLoa.setLoaCstCntrID("0000000000000000");
+        mockLoa.setLoaPrjID("000000000000");
+        mockLoa.setLoaActvtyID("00000000000");
+        mockLoa.setLoaCstCd("0000000000000000");
+        mockLoa.setLoaWrkOrdID("0000000000000000");
+        mockLoa.setLoaFnclArID("000000");
+        mockLoa.setLoaScrtyCoopCustCd("A");
+        mockLoa.setLoaEndFyTx(0);
+        mockLoa.setLoaBgFyTx(0);
+        mockLoa.setLoaBgtRstrCd("A");
+        mockLoa.setLoaBgtSubActCd("A");
+        mockLoa.setUpdatedAt(LocalDateTime.now());
+
+        return mockLoa;
+    }
+
+    // Create mock tacs
+    public ArrayList<TransportationAccountingCode> createMockTacs(int amount) {
+        ArrayList<TransportationAccountingCode> mockTacs = new ArrayList<TransportationAccountingCode>();
+
+        for (int index = 0; index != amount; index++) {
+            TransportationAccountingCode mockTac = createMockTac();
+            mockTacs.add(mockTac);
+        }
+
+        return mockTacs;
+    }
+
+    // Create a mock tac
+    public TransportationAccountingCode createMockTac() {
+        // Create a test TAC(s)
+        TransportationAccountingCode mockTac = new TransportationAccountingCode();
+
+        UUID testUUID = UUID.randomUUID();
+
+        mockTac.setId(testUUID);
+        mockTac.setTac("0000");
+        mockTac.setTacSysID("20000");
+        mockTac.setLoaSysID("10002");
+        mockTac.setTacSysID("2017");
+        mockTac.setTacFnBlModCd("W");
+        mockTac.setOrgGrpDfasCd("HS");
+        mockTac.setTacMvtDsgID("test");
+        mockTac.setTacTyCd("O");
+        mockTac.setTacUseCd("N");
+        mockTac.setTacMajClmtID("12345");
+        mockTac.setTacBillActTxt("123456");
+        mockTac.setTacCostCtrNm("12345");
+        mockTac.setBuic("A");
+        mockTac.setTacHistCd("A");
+        mockTac.setTacStatCd("I");
+        mockTac.setTrnsprtnAcntTx("TEST HOUSING 1");
+        mockTac.setDdActvtyAdrsID("test");
+        mockTac.setTacBlldAddFrstLnTx("test");
+        mockTac.setTacBlldAddScndLnTx("test");
+        mockTac.setTacBlldAddThrdLnTx("test");
+        mockTac.setTacBlldAddFrthLnTx("test");
+        mockTac.setTacFnctPocNm("test");
+        mockTac.setTrnsprtnAcntBgnDt(LocalDateTime.now());
+        mockTac.setTrnsprtnAcntEndDt(LocalDateTime.now());
+        mockTac.setUpdatedAt(LocalDateTime.now());
+
+        return mockTac;
+    }
+}


### PR DESCRIPTION
In this PR the following functionality is introduced:

1. Duplicate Loas are removed before any update or inserts- Any Loa that has a non-unique loa_sys_id, and its Id is not used in TAC db table loa_id column is deleted
2. Loa updates - If a loa exist with the same loa_sys_id then the load is updated with the incoming one instead of a new insert
3. TAC updates - If there is a TAC code that already exist with the same tac_sys_id as the incoming one then the current TAC is updated instead of a new insert
4. On TAC and LOA updates rollback is being used. If one query fail in the batch the connection will rollback any changes that were made
5. Additional logging was added. TAC and LOA Ids are logged when updates occur.