### PR TITLE
Changed db queries for better performance

### DIFF
--- a/src/main/java/com/milmove/trdmlambda/milmove/service/DatabaseService.java
+++ b/src/main/java/com/milmove/trdmlambda/milmove/service/DatabaseService.java
@@ -365,14 +365,15 @@ public class DatabaseService {
         }
     }
 
-    public ArrayList<LineOfAccounting> getAllLoas() throws SQLException {
+    // Only query for needed data for performance reasons
+    public ArrayList<LineOfAccounting> getCurrentLoaInformation() throws SQLException {
 
         logger.info("retrieving all LOAs");
 
         ArrayList<LineOfAccounting> loas;
 
         // Select all loas
-        String sql = "SELECT * FROM lines_of_accounting";
+        String sql = "SELECT id, loa_sys_id, loa_dpt_id, updated_at FROM lines_of_accounting";
 
         try (Connection conn = this.getConnection(); PreparedStatement pstmt = conn.prepareStatement(sql);) {
             ResultSet rs = pstmt.executeQuery();
@@ -419,59 +420,6 @@ public class DatabaseService {
             loa.setId(UUID.fromString(rs.getString(LinesOfAccountingDatabaseColumns.id)));
             loa.setLoaSysID(rs.getString(LinesOfAccountingDatabaseColumns.loaSysId));
             loa.setLoaDptID(rs.getString(LinesOfAccountingDatabaseColumns.loaDptId));
-            loa.setLoaTnsfrDptNm(rs.getString(LinesOfAccountingDatabaseColumns.loaTnsfrDptNm));
-            loa.setLoaBafID(rs.getString(LinesOfAccountingDatabaseColumns.loaBafId));
-            loa.setLoaTrsySfxTx(rs.getString(LinesOfAccountingDatabaseColumns.loaTrsySfxTx));
-            loa.setLoaMajClmNm(rs.getString(LinesOfAccountingDatabaseColumns.loaMajClmNm));
-            loa.setLoaOpAgncyID(rs.getString(LinesOfAccountingDatabaseColumns.loaOpAgncy_id));
-            loa.setLoaAlltSnID(rs.getString(LinesOfAccountingDatabaseColumns.loaAlltSnId));
-            loa.setLoaPgmElmntID(rs.getString(LinesOfAccountingDatabaseColumns.loaPgmElmntId));
-            loa.setLoaTskBdgtSblnTx(rs.getString(LinesOfAccountingDatabaseColumns.loaTskBdgtSblnTx));
-            loa.setLoaDfAgncyAlctnRcpntID(rs.getString(LinesOfAccountingDatabaseColumns.loaDfAgncyAlctnRcpntId));
-            loa.setLoaJbOrdNm(rs.getString(LinesOfAccountingDatabaseColumns.loaJbOrdNm));
-            loa.setLoaSbaltmtRcpntID(rs.getString(LinesOfAccountingDatabaseColumns.loaSbaltmtRcpntId));
-            loa.setLoaWkCntrRcpntNm(rs.getString(LinesOfAccountingDatabaseColumns.loaWkCntrRcpntNm));
-            loa.setLoaMajRmbsmtSrcID(rs.getString(LinesOfAccountingDatabaseColumns.loaMajRmbsmtSrcId));
-            loa.setLoaDtlRmbsmtSrcID(rs.getString(LinesOfAccountingDatabaseColumns.loaDtlRmbsmtSrcId));
-            loa.setLoaCustNm(rs.getString(LinesOfAccountingDatabaseColumns.loaCustNm));
-            loa.setLoaObjClsID(rs.getString(LinesOfAccountingDatabaseColumns.loaObjClsId));
-            loa.setLoaSrvSrcID(rs.getString(LinesOfAccountingDatabaseColumns.loaSrvSrcId));
-            loa.setLoaSpclIntrID(rs.getString(LinesOfAccountingDatabaseColumns.loaSpclIntrId));
-            loa.setLoaBdgtAcntClsNm(rs.getString(LinesOfAccountingDatabaseColumns.loaBdgtAcntClsNm));
-            loa.setLoaDocID(rs.getString(LinesOfAccountingDatabaseColumns.loaDocId));
-            loa.setLoaClsRefID(rs.getString(LinesOfAccountingDatabaseColumns.loaClsRefId));
-            loa.setLoaInstlAcntgActID(rs.getString(LinesOfAccountingDatabaseColumns.loaInstlAcntgActId));
-            loa.setLoaLclInstlID(rs.getString(LinesOfAccountingDatabaseColumns.loaLclInstlId));
-            loa.setLoaFmsTrnsactnID(rs.getString(LinesOfAccountingDatabaseColumns.loaFmsTrnsactnId));
-            loa.setLoaDscTx(rs.getString(LinesOfAccountingDatabaseColumns.loaDscTx));
-            loa.setLoaFnctPrsNm(rs.getString(LinesOfAccountingDatabaseColumns.loaFnctPrsNm));
-            loa.setLoaStatCd(rs.getString(LinesOfAccountingDatabaseColumns.loaStatCd));
-            loa.setLoaHistStatCd(rs.getString(LinesOfAccountingDatabaseColumns.loaHistStatCd));
-            loa.setLoaHsGdsCd(rs.getString(LinesOfAccountingDatabaseColumns.loaHsGdsCd));
-            loa.setOrgGrpDfasCd(rs.getString(LinesOfAccountingDatabaseColumns.orgGrpDfasCd));
-            loa.setLoaUic(rs.getString(LinesOfAccountingDatabaseColumns.loaUic));
-            loa.setLoaTrnsnID(rs.getString(LinesOfAccountingDatabaseColumns.loaTrnsnId));
-            loa.setLoaSubAcntID(rs.getString(LinesOfAccountingDatabaseColumns.loaSubAcntId));
-            loa.setLoaBetCd(rs.getString(LinesOfAccountingDatabaseColumns.loaBetCd));
-            loa.setLoaFndTyFgCd(rs.getString(LinesOfAccountingDatabaseColumns.loaFndTyFgCd));
-            loa.setLoaBgtLnItmID(rs.getString(LinesOfAccountingDatabaseColumns.loaBgtLnItmId));
-            loa.setLoaScrtyCoopImplAgncCd(rs.getString(LinesOfAccountingDatabaseColumns.loaScrtyCoopImplAgncCd));
-            loa.setLoaScrtyCoopDsgntrCd(rs.getString(LinesOfAccountingDatabaseColumns.loaScrtyCoopDsgntrCd));
-            loa.setLoaScrtyCoopLnItmID(rs.getString(LinesOfAccountingDatabaseColumns.loaScrtyCoopLnItmId));
-            loa.setLoaAgncDsbrCd(rs.getString(LinesOfAccountingDatabaseColumns.loaAgncDsbrCd));
-            loa.setLoaAgncAcntngCd(rs.getString(LinesOfAccountingDatabaseColumns.loaAgncAcntngCd));
-            loa.setLoaFndCntrID(rs.getString(LinesOfAccountingDatabaseColumns.loaFndCntrId));
-            loa.setLoaCstCntrID(rs.getString(LinesOfAccountingDatabaseColumns.loaCstCntrId));
-            loa.setLoaPrjID(rs.getString(LinesOfAccountingDatabaseColumns.loaPrjId));
-            loa.setLoaActvtyID(rs.getString(LinesOfAccountingDatabaseColumns.loaActvtyId));
-            loa.setLoaCstCd(rs.getString(LinesOfAccountingDatabaseColumns.loaCstCd));
-            loa.setLoaWrkOrdID(rs.getString(LinesOfAccountingDatabaseColumns.loaWrkOrdId));
-            loa.setLoaFnclArID(rs.getString(LinesOfAccountingDatabaseColumns.loaFnclArId));
-            loa.setLoaScrtyCoopCustCd(rs.getString(LinesOfAccountingDatabaseColumns.loaScrtyCoopCustCd));
-            loa.setLoaEndFyTx(Integer.valueOf(rs.getString(LinesOfAccountingDatabaseColumns.loaEndFyTx)));
-            loa.setLoaBgFyTx(Integer.valueOf(rs.getString(LinesOfAccountingDatabaseColumns.loaBgFyTx)));
-            loa.setLoaBgtRstrCd(rs.getString(LinesOfAccountingDatabaseColumns.loaBgtRstrCd));
-            loa.setLoaBgtSubActCd(rs.getString(LinesOfAccountingDatabaseColumns.loaBgtSubActCd));
 
             if (rs.getString(LinesOfAccountingDatabaseColumns.updatedAt).length() == 25) {
                 loa.setUpdatedAt(LocalDateTime.parse(rs.getString(LinesOfAccountingDatabaseColumns.updatedAt), timeFormatterLen25));
@@ -485,47 +433,29 @@ public class DatabaseService {
         return loas;
     }
 
-    public ArrayList<TransportationAccountingCode> getAllTacs() throws SQLException {
+    // Only query for needed data for performance reasons
+    public ArrayList<TransportationAccountingCode> getCurrentTacInformation() throws SQLException {
 
         logger.info("retrieving all TACs");
 
         ArrayList<TransportationAccountingCode> tacs = new ArrayList<TransportationAccountingCode>();
 
         // Select all TACs
-        String sql = "SELECT * FROM transportation_accounting_codes;";
+        String sql = "SELECT id, tac, loa_id FROM transportation_accounting_codes;";
 
         try (Connection conn = this.getConnection(); PreparedStatement pstmt = conn.prepareStatement(sql)) {
             ResultSet rs = pstmt.executeQuery();
             while (rs.next()) {
                 TransportationAccountingCode tac = new TransportationAccountingCode();
                 tac.setId(UUID.fromString(rs.getString(TransportationAccountingCodesDatabaseColumns.id)));
-                tac.setTacSysID(rs.getString(TransportationAccountingCodesDatabaseColumns.tacSysId));
-                tac.setLoaSysID(rs.getString(TransportationAccountingCodesDatabaseColumns.loaSysId));
+                if (rs.getString(TransportationAccountingCodesDatabaseColumns.loaId) != null
+                && rs.getString(TransportationAccountingCodesDatabaseColumns.loaId) != "null") {
+                    tac.setLoaID(UUID.fromString(rs.getString(TransportationAccountingCodesDatabaseColumns.loaId)));
+                } else {
+                    UUID nilUUID = new UUID(0,0); // represents a nil UUID
+                    tac.setLoaID(nilUUID);
+                }
                 tac.setTac(rs.getString(TransportationAccountingCodesDatabaseColumns.tac));
-                tac.setTacFyTxt(rs.getString(TransportationAccountingCodesDatabaseColumns.tacFnBlModCd));
-                tac.setTacFnBlModCd(rs.getString(TransportationAccountingCodesDatabaseColumns.tacFnBlModCd));
-                tac.setOrgGrpDfasCd(rs.getString(TransportationAccountingCodesDatabaseColumns.orgGrpDfasCd));
-                tac.setTacTyCd(rs.getString(TransportationAccountingCodesDatabaseColumns.tacTyCd));
-                tac.setTacUseCd(rs.getString(TransportationAccountingCodesDatabaseColumns.tacUseCd));
-                tac.setTacMajClmtID(rs.getString(TransportationAccountingCodesDatabaseColumns.tacMajClmtId));
-                tac.setTacCostCtrNm(rs.getString(TransportationAccountingCodesDatabaseColumns.tacCostCtrNm));
-                tac.setTacStatCd(rs.getString(TransportationAccountingCodesDatabaseColumns.tacStatCd));
-                tac.setTrnsprtnAcntTx(rs.getString(TransportationAccountingCodesDatabaseColumns.trnsprtnAcntTx));
-                tac.setDdActvtyAdrsID(rs.getString(TransportationAccountingCodesDatabaseColumns.ddActvtyAdrsId));
-                tac.setTacBlldAddFrstLnTx(
-                        rs.getString(TransportationAccountingCodesDatabaseColumns.tacBlldAddFrstLnTx));
-                tac.setTacBlldAddScndLnTx(
-                        rs.getString(TransportationAccountingCodesDatabaseColumns.tacBlldAddScndLnTx));
-                tac.setTacBlldAddThrdLnTx(
-                        rs.getString(TransportationAccountingCodesDatabaseColumns.tacBlldAddThrdLnTx));
-                tac.setTacBlldAddFrthLnTx(
-                        rs.getString(TransportationAccountingCodesDatabaseColumns.tacBlldAddFrthLnTx));
-                tac.setTacFnctPocNm(rs.getString(TransportationAccountingCodesDatabaseColumns.tacFnctPocNm));
-                tac.setTacMvtDsgID(rs.getString(TransportationAccountingCodesDatabaseColumns.tacMvtDsgId));
-                tac.setTacBillActTxt(rs.getString(TransportationAccountingCodesDatabaseColumns.tacBillActTxt));
-                tac.setBuic(rs.getString(TransportationAccountingCodesDatabaseColumns.buic));
-                tac.setTacHistCd(rs.getString(TransportationAccountingCodesDatabaseColumns.tacHistCd));
-
                 tacs.add(tac);
             }
 
@@ -533,25 +463,5 @@ public class DatabaseService {
             return tacs;
         }
 
-    }
-
-    // Identify duplicate LOA.loaSysIds
-    public ArrayList<LineOfAccounting> getDuplicateLoasToDelete() throws SQLException {
-
-        logger.info(
-                "identifying LOAs to delete based on loa records with a non unique loa_sys_id and not referenced in the transportation_accounting_codes table");
-
-        // Select all duplicate loa_sys_id
-        String sql = "Select * From lines_of_accounting Where loa_sys_id in (SELECT loa_sys_id FROM lines_of_accounting GROUP BY loa_sys_id HAVING COUNT(*) > 1) AND id NOT IN (SELECT loa_id FROM transportation_accounting_codes WHERE loa_id is NOT NULL)";
-
-        try (Connection conn = this.getConnection(); PreparedStatement pstmt = conn.prepareStatement(sql)) {
-            ResultSet rs = pstmt.executeQuery();
-
-            ArrayList<LineOfAccounting> loas;
-            loas = dbLoasToModel(rs);
-
-            logger.info("finished identifying LOAs to delete");
-            return loas;
-        }
     }
 }

--- a/src/main/java/com/milmove/trdmlambda/milmove/util/Trdm.java
+++ b/src/main/java/com/milmove/trdmlambda/milmove/util/Trdm.java
@@ -160,10 +160,10 @@ public class Trdm {
                 receivedData = true;
 
                 // Get all Tacs
-                ArrayList<TransportationAccountingCode> currentTacs = databaseService.getAllTacs();
+                ArrayList<TransportationAccountingCode> currentTacs = databaseService.getCurrentTacInformation();
 
                 // Get all loas
-                ArrayList<LineOfAccounting> currentLoas = databaseService.getAllLoas();
+                ArrayList<LineOfAccounting> currentLoas = databaseService.getCurrentLoaInformation();
 
                 // Identify Loas to delete based on if their loaSysId is not unique, their id/primary key is not referenced in TACS loa_id and the loa is the latest
                 ArrayList<LineOfAccounting> loasToDelete = identifyDuplicateLoasToDelete(currentLoas, currentTacs);

--- a/src/test/java/com/milmove/trdmlambda/milmove/util/DatabaseServiceTest.java
+++ b/src/test/java/com/milmove/trdmlambda/milmove/util/DatabaseServiceTest.java
@@ -63,7 +63,7 @@ public class DatabaseServiceTest {
           // line_of_accounting
     void getAllLoasTest() throws SQLException {
         setUpTests();
-        ArrayList<LineOfAccounting> loas = spyDatabaseService.getAllLoas();
+        ArrayList<LineOfAccounting> loas = spyDatabaseService.getCurrentLoaInformation();
         assertTrue(loas.size() > 0);
     }
 
@@ -71,7 +71,7 @@ public class DatabaseServiceTest {
           // transportation_accounting_codes
     void getAllTacsTest() throws Exception {
         setUpTests();
-        ArrayList<TransportationAccountingCode> tacs = spyDatabaseService.getAllTacs();
+        ArrayList<TransportationAccountingCode> tacs = spyDatabaseService.getCurrentTacInformation();
         assertTrue(tacs.size() > 0);
     }
 
@@ -160,7 +160,7 @@ public class DatabaseServiceTest {
         // Make sure the test_db connection is returned when .getConnection is called
         assertEquals(conn2, spyDatabaseService.getConnection());
 
-        ArrayList<LineOfAccounting> dbTacs = spyDatabaseService.getAllLoas();
+        ArrayList<LineOfAccounting> dbTacs = spyDatabaseService.getCurrentLoaInformation();
 
         List<LineOfAccounting> codes = dbTacs.stream().filter(tac -> tac.getId().equals(testLoas.get(0).getId()))
                 .collect(Collectors.toList());
@@ -254,7 +254,7 @@ public class DatabaseServiceTest {
         // Make sure the test_db connection is returned when .getConnection is called
         assertEquals(conn2, spyDatabaseService.getConnection());
 
-        ArrayList<TransportationAccountingCode> dbTacs = spyDatabaseService.getAllTacs();
+        ArrayList<TransportationAccountingCode> dbTacs = spyDatabaseService.getCurrentTacInformation();
 
         List<TransportationAccountingCode> codes = dbTacs.stream()
                 .filter(tac -> tac.getId().equals(testTacs.get(0).getId())).collect(Collectors.toList());
@@ -296,7 +296,7 @@ public class DatabaseServiceTest {
         // Make sure the test_db connection is returned when .getConnection is called
         assertEquals(conn2, spyDatabaseService.getConnection());
 
-        ArrayList<LineOfAccounting> loasList = spyDatabaseService.getAllLoas();
+        ArrayList<LineOfAccounting> loasList = spyDatabaseService.getCurrentLoaInformation();
         List<UUID> loaIds = loasList.stream().map(loa -> loa.getId()).collect(Collectors.toList());
 
         assertFalse(loaIds.contains(testLoas.get(0).getId()));

--- a/src/test/java/com/milmove/trdmlambda/milmove/util/TrdmTest.java
+++ b/src/test/java/com/milmove/trdmlambda/milmove/util/TrdmTest.java
@@ -406,8 +406,10 @@ class TrdmTest {
         TransportationAccountingCode mockTac = new TransportationAccountingCode();
 
         UUID testUUID = UUID.randomUUID();
+        UUID testLoaUUID = UUID.randomUUID();
 
         mockTac.setId(testUUID);
+        mockTac.setLoaID(testLoaUUID);
         mockTac.setTac("0000");
         mockTac.setTacSysID("20000");
         mockTac.setLoaSysID("10002");


### PR DESCRIPTION
No functionality change. Instead of bringing in all TACs and LOAs data I am only bringing in data that is needed.

The issue was that staging db has a statement_timeout of 10 seconds. This caused the getAllTacs query and getAllLoas query to be canceled by the DB for taking too long. This is an attempt to tune the queries so that they execute faster and are not canceled by staging db.

## Testing

1.  Go to main and run the test
2. Take note of the Total time it took. For me I have 1,000,010 million Tacs and 214 Loas. Test completed in 6.856 seconds
3. Run the tests on this branch
4. Take note of the Total time it took. For me with the same amount of Tacs and Loas as above it took 3.558 seconds