### PR TITLE
Performance tuned the LOA delete functionality

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 	</parent>
 	<groupId>com.milmove.trdmlambda</groupId>
 	<artifactId>trdm-lambda</artifactId>
-	<version>1.0.3.6</version>
+	<version>1.0.3.7</version>
 	<name>trdm java spring interface</name>
 	<description>Project for deploying a Java TRDM interfacer for TGET data.</description>
 	<properties>


### PR DESCRIPTION
This is a performance tune for the delete function which took a large amount of time in staging and timed out. Used more Set data structures to eliminate duplicates within traversing logic. Also there was some logic where I was looping through all TACs in a foreach. That logic has been changed to filter the TAC loa_id one time and then check in a foreach for the LOA to be there. I created somewhat of a way to load 1000000 TAC and LOA with random amounts of duplicates and random amounts of LOAs that are referenced by a TAC and these changes increased performance drastically. The complete execution time for the delete functionality to process 1,000,000 LOA codes with 1,000,000 LOA codes with non-unique loa_sys_ids,  and 607,037 amount of duplicate unreferenced LOA codes is just under 1 second. Also added additional logging so I can get some information on how many LOA codes and TAC codes there are and how long each step is taking.

![image](https://github.com/transcom/trdm-lambda/assets/136514590/d8f86bdd-a161-463c-b53f-7e2f51ea0d71)

In the screenshot above notice " identifying duplicate Line of Accounting codes to delete" is time stamped at 15:20:07.699 and "finished identifying duplicate Line of Accounting codes to delete" is time stamped at 15:20:08.186. All tests run and pass  with no changes. Functionality remains the same but just coded in a better way.