### PR TITLE
Performance Update to identifying duplicates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 	</parent>
 	<groupId>com.milmove.trdmlambda</groupId>
 	<artifactId>trdm-lambda</artifactId>
-	<version>1.0.3.7</version>
+	<version>1.0.3.8</version>
 	<name>trdm java spring interface</name>
 	<description>Project for deploying a Java TRDM interfacer for TGET data.</description>
 	<properties>

--- a/src/test/java/com/milmove/trdmlambda/milmove/util/DatabaseServiceTest.java
+++ b/src/test/java/com/milmove/trdmlambda/milmove/util/DatabaseServiceTest.java
@@ -262,6 +262,49 @@ public class DatabaseServiceTest {
         assertEquals(testTacs.get(0).getTac(), codes.get(0).getTac());
     }
 
+     // Test that we get a list of loa_sys_ids that occur more than once
+    // DatabaseService.getLoaSysIdCountGreaterThan1()
+    @Test
+    void testGetLoaSysIdCountGreaterThan1() throws Exception {
+
+        setUpTests();
+
+        LocalDateTime time = LocalDateTime.now();
+        int mo = time.getMonthValue();
+        int day = time.getDayOfMonth();
+        int year = time.getYear();
+        int hr = time.getHour();
+        int min = time.getMinute();
+        int sec = time.getSecond();
+
+        String dayTime = Integer.toString(mo) + Integer.toString(day) + Integer.toString(year) + Integer.toString(hr) + Integer.toString(hr) + Integer.toString(min) + Integer.toString(sec);
+
+        String testLoaSysId = "dum" + dayTime;
+        String nonDupLoaSysId = testLoaSysId + "a";
+
+        ArrayList<LineOfAccounting> testLoas = createMockLoas(3);
+
+        testLoas.get(0).setLoaSysID(testLoaSysId);
+        testLoas.get(1).setLoaSysID(testLoaSysId);
+        testLoas.get(2).setLoaSysID(nonDupLoaSysId);
+
+        // Invoke insertLineOfAccountingCodes() with test LOA(s)
+        spyDatabaseService.insertLinesOfAccounting(testLoas);
+
+        Connection conn1 = createTestDbConnection();
+
+        // Mock the DatabaseService.getConnection() to return the test_db connection
+        doReturn(conn1).when(spyDatabaseService).getConnection();
+
+        // Make sure the test_db connection is returned when .getConnection is called
+        assertEquals(conn1, spyDatabaseService.getConnection());
+
+        ArrayList<String> loaSysIds = spyDatabaseService.getLoaSysIdCountGreaterThan1();
+
+        assertTrue(loaSysIds.contains(testLoaSysId));
+        assertFalse(loaSysIds.contains(nonDupLoaSysId));
+    }
+
     // Test that we can delete a list of loas
     // DatabaseService.deleteLoas()
     @Test

--- a/src/test/java/com/milmove/trdmlambda/milmove/util/TrdmTest.java
+++ b/src/test/java/com/milmove/trdmlambda/milmove/util/TrdmTest.java
@@ -292,11 +292,19 @@ class TrdmTest {
         currentLoas.get(5).setLoaSysID("NoDupe" + rand.nextInt(1000) + rand.nextInt(1000)); // No delete
         currentLoas.get(6).setLoaSysID("NoDupe" + rand.nextInt(1000) + rand.nextInt(1000)); // No Delete
 
+        // List of duplicateLoas
+        ArrayList<String> duplicateLoaSysIds = new ArrayList<String>();
+        duplicateLoaSysIds.add(currentLoas.get(0).getLoaSysID());
+        duplicateLoaSysIds.add(currentLoas.get(1).getLoaSysID());
+        duplicateLoaSysIds.add(currentLoas.get(2).getLoaSysID());
+        duplicateLoaSysIds.add(currentLoas.get(3).getLoaSysID());
+        duplicateLoaSysIds.add(currentLoas.get(4).getLoaSysID());
 
-        ArrayList<LineOfAccounting> loasToDelete = trdm.identifyDuplicateLoasToDelete(currentLoas, currentTacs);
+
+        ArrayList<LineOfAccounting> loasToDelete = trdm.identifyDuplicateLoasToDelete(currentLoas, currentTacs, duplicateLoaSysIds);
         List<UUID> loaIds = loasToDelete.stream().map(loa -> loa.getId()).collect(Collectors.toList());
 
-        // Loas that should be deleted should be returned for deletetion
+        // Loas that should be deleted should be returned for deletion
         assertTrue(loaIds.contains(currentLoas.get(2).getId()));
         assertTrue(loaIds.contains(currentLoas.get(3).getId()));
 


### PR DESCRIPTION
This is another attempt to make the deletion of LOAs faster. The functionality timed out again in STG and is taking too long. This time it was specifically identifying duplicates. In this change I am removing the Java Stream Implementation that filters a list of LOA codes wile in a or loop that loops through each LOA code to see if it is a duplicate. From adding additional logging I have found out that there are over 2 Million TAC codes and just around 203,000 Loa codes. The Stream API for JAVA is not efficient enough so this time I am making a database call to get loa_sys_Ids that have a count greater than 1. This means that there are duplicates or this loa_sys_id. I am hoping that leaving this part to the DB and not loops in java will make this much faster. I am now taking that result form the DB doing a simple ArrayList.contains with each loa to tell i the specific LOA is a duplicate or not. I have to balance out making sure queries are not too long as well as making sure there isn't too much looping logic in java. I believe the sql query is simple enough to be fast and the java for each loop through the LOA codes and seeing if it has a loa_sys_id in that list is simple and should be much faster.