### PR TITLE
Excluding LOA codes with null updated_at values

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 	</parent>
 	<groupId>com.milmove.trdmlambda</groupId>
 	<artifactId>trdm-lambda</artifactId>
-	<version>1.0.3.8</version>
+	<version>1.0.3.9</version>
 	<name>trdm java spring interface</name>
 	<description>Project for deploying a Java TRDM interfacer for TGET data.</description>
 	<properties>

--- a/src/main/java/com/milmove/trdmlambda/milmove/service/DatabaseService.java
+++ b/src/main/java/com/milmove/trdmlambda/milmove/service/DatabaseService.java
@@ -419,15 +419,19 @@ public class DatabaseService {
             loa.setLoaSysID(rs.getString(LinesOfAccountingDatabaseColumns.loaSysId));
             loa.setLoaDptID(rs.getString(LinesOfAccountingDatabaseColumns.loaDptId));
 
-            if (rs.getString(LinesOfAccountingDatabaseColumns.updatedAt).length() == 25) {
-                loa.setUpdatedAt(LocalDateTime.parse(rs.getString(LinesOfAccountingDatabaseColumns.updatedAt),
-                        timeFormatterLen25));
-            } else if (rs.getString(LinesOfAccountingDatabaseColumns.updatedAt).length() == 26) {
-                loa.setUpdatedAt(LocalDateTime.parse(rs.getString(LinesOfAccountingDatabaseColumns.updatedAt),
-                        timeFormatterLen26));
-            }
+            if (rs.getString(LinesOfAccountingDatabaseColumns.updatedAt) != null) {
+                if (rs.getString(LinesOfAccountingDatabaseColumns.updatedAt).length() == 25) {
+                    loa.setUpdatedAt(LocalDateTime.parse(rs.getString(LinesOfAccountingDatabaseColumns.updatedAt),
+                            timeFormatterLen25));
+                } else if (rs.getString(LinesOfAccountingDatabaseColumns.updatedAt).length() == 26) {
+                    loa.setUpdatedAt(LocalDateTime.parse(rs.getString(LinesOfAccountingDatabaseColumns.updatedAt),
+                            timeFormatterLen26));
+                }
 
-            loas.add(loa);
+                loas.add(loa);
+            } else {
+                logger.info("Excluding LOA with ID: " + loa.getId() + " because updated_at is null");
+            }
         }
 
         return loas;


### PR DESCRIPTION
The last release failed because some LOA codes in STG have an updated_at value of null even though there is a not null constraint on the column. That constraint is applied locally as well but all LOA codes locally have a value for updated_at. Some codes in STG must have been in the table before the NOT NULL constraint was applied to the column. Other than that there is no way to insert a LOA without an updated_at value. Was able to remove the constraint locally to change some LOAs to have an updated_at vale of null and reproduce the error. Was able to code against that error and that is what these changes are here. If the updated_at value of a LOA is null then there is no way we can compare it to the other LOA codes with the same loa_sys_Id for deletion.