### PR TITLE
B-20564: Email for Missing Data

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 	</parent>
 	<groupId>com.milmove.trdmlambda</groupId>
 	<artifactId>trdm-lambda</artifactId>
-	<version>1.0.3.10</version>
+	<version>1.0.3.11</version>
 	<name>trdm java spring interface</name>
 	<description>Project for deploying a Java TRDM interfacer for TGET data.</description>
 	<properties>
@@ -27,6 +27,11 @@
 			<groupId>software.amazon.awssdk</groupId>
 			<artifactId>rds</artifactId>
 			<version>2.21.40</version>
+		</dependency>
+		<dependency>
+			<groupId>software.amazon.awssdk</groupId>
+			<artifactId>ses</artifactId>
+			<version>2.26.20</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/src/main/java/com/milmove/trdmlambda/milmove/service/EmailService.java
+++ b/src/main/java/com/milmove/trdmlambda/milmove/service/EmailService.java
@@ -78,8 +78,7 @@ public class EmailService {
 
         logger.info("finished sending Malformed LOA Data email through from: " + this.sender + " to " + this.recipient);
     }
-
-    // 
+ 
     public void send(SesClient client) throws MessagingException {
         logger.info("start of EmailService.send()");
         Destination destination = Destination.builder()

--- a/src/main/java/com/milmove/trdmlambda/milmove/service/EmailService.java
+++ b/src/main/java/com/milmove/trdmlambda/milmove/service/EmailService.java
@@ -1,0 +1,120 @@
+package com.milmove.trdmlambda.milmove.service;
+
+import org.glassfish.jaxb.runtime.v2.schemagen.xmlschema.List;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import ch.qos.logback.classic.Logger;
+import jakarta.mail.MessagingException;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.ses.SesClient;
+import software.amazon.awssdk.services.ses.model.Content;
+import software.amazon.awssdk.services.ses.model.Destination;
+import software.amazon.awssdk.services.ses.model.Message;
+import software.amazon.awssdk.services.ses.model.Body;
+import software.amazon.awssdk.services.ses.model.SendEmailRequest;
+import software.amazon.awssdk.services.ses.model.SesException;
+
+import java.util.ArrayList;
+
+@Service
+public class EmailService {
+
+    private Logger logger = (Logger) LoggerFactory.getLogger(EmailService.class);
+
+    private SesClient sesClient;
+    private String sender;
+    private String recipient;
+    private String subject;
+    private String bodyHTML;
+
+    public EmailService() {
+        logger.info("starting initialization of Email Service");
+        this.sesClient = SesClient.builder()
+                .region(Region.of("us-gov-west-1"))
+                .credentialsProvider(DefaultCredentialsProvider.create())
+                .build();
+        this.sender = "milmove-developers@caci.com";
+        this.recipient = "milmove-developers@caci.com";
+
+        logger.info("finished initializing Email Service");
+    }
+
+    // Prepare and send Malformed Data Email for Transportation Accounting Codes
+    public void sendMalformedTACDataEmail(ArrayList<String> tacSysIds) {
+        logger.info("starting to send Malformed TAC Data email through from: " + this.sender + " to " + this.recipient + " with " + tacSysIds.size() + " TACs");
+
+        this.bodyHTML = "<html>" + "<head></head>" + "<body>" + "<h1>Malformed TAC Data</h1>"
+        + "<p> See all malformed TAC codes represented by their tacSysId: </p>" + "</body>" + "</html>";
+
+        this.subject = "Malformed Transportation Accounting Codes";
+
+        try {
+            send(this.sesClient);
+            sesClient.close();
+        } catch (MessagingException e) {
+            logger.error("error in SendMessageEmailRequest: " + e.getStackTrace());
+        }
+
+        logger.info("finished sending Malformed TAC Data email through from: " + this.sender + " to " + this.recipient);
+    }
+
+    // Prepare and send Malformed Data Email for Line of Accounting Codes
+    public void sendMalformedLOADataEmail(ArrayList<String> loaSysIds) {
+        logger.info("starting to send Malformed LOA Data email through from: " + this.sender + " to " + this.recipient + " with " + loaSysIds.size() + " LOAs");
+
+        this.bodyHTML = "<html>" + "<head></head>" + "<body>" + "<h1>Malformed LOA Data</h1>"
+        + "<p> See all malformed LOA codes represented by their loaSysId: </p>" + "</body>" + "</html>";
+
+        this.subject = "Malformed Line of Accounting Codes";
+
+        try {
+            send(this.sesClient);
+            sesClient.close();
+        } catch (MessagingException e) {
+            logger.error("error in SendMessageEmailRequest: " + e.getStackTrace());
+        }
+
+        logger.info("finished sending Malformed LOA Data email through from: " + this.sender + " to " + this.recipient);
+    }
+
+    // 
+    public void send(SesClient client) throws MessagingException {
+        logger.info("start of EmailService.send()");
+        Destination destination = Destination.builder()
+                .toAddresses(this.recipient)
+                .build();
+
+        Content content = Content.builder()
+                .data(this.bodyHTML)
+                .build();
+
+        Content sub = Content.builder()
+                .data(this.subject)
+                .build();
+
+        Body body = Body.builder()
+                .html(content)
+                .build();
+
+        Message msg = Message.builder()
+                .subject(sub)
+                .body(body)
+                .build();
+
+        SendEmailRequest emailRequest = SendEmailRequest.builder()
+                .destination(destination)
+                .message(msg)
+                .source(sender)
+                .build();
+
+        try {
+            logger.info("EmailService.send() - sending email");
+            client.sendEmail(emailRequest);
+            logger.info("finished EmailService.send()");
+        } catch (SesException e) {
+            logger.error("error in Email Service: " + e.awsErrorDetails().errorMessage());
+        }
+    }
+}

--- a/src/main/java/com/milmove/trdmlambda/milmove/util/LineOfAccountingParser.java
+++ b/src/main/java/com/milmove/trdmlambda/milmove/util/LineOfAccountingParser.java
@@ -22,12 +22,14 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 import com.milmove.trdmlambda.milmove.model.LineOfAccounting;
+import com.milmove.trdmlambda.milmove.service.EmailService;
 
 @Component
 public class LineOfAccountingParser {
     private Logger logger = (Logger) LoggerFactory.getLogger(LineOfAccountingParser.class);
     // Create our map for TGET parsing
     Map<String, Integer> columnNamesAndLocations = new HashMap<>();
+    private ArrayList<String> skippedLoaSysIds = new ArrayList<String>();
 
     private static final String[] expectedColumnNames = {
             "LOA_SYS_ID", "LOA_DPT_ID", "LOA_TNSFR_DPT_NM", "LOA_BAF_ID", "LOA_TRSY_SFX_TX", "LOA_MAJ_CLM_NM",
@@ -43,7 +45,7 @@ public class LineOfAccountingParser {
             "LOA_FNCL_AR_ID", "LOA_SCRTY_COOP_CUST_CD", "LOA_END_FY_TX", "LOA_BG_FY_TX", "LOA_BGT_RSTR_CD",
             "LOA_BGT_SUB_ACT_CD", "ROW_STS_CD" };
 
-    public List<LineOfAccounting> parse(byte[] fileContent, XMLGregorianCalendar trdmLastUpdate)
+    public List<LineOfAccounting> parse(byte[] fileContent, XMLGregorianCalendar trdmLastUpdate, EmailService emailService)
             throws RuntimeException {
         logger.info("beginning to parse LOA TGET data");
         List<LineOfAccounting> codes = new ArrayList<>();
@@ -81,7 +83,7 @@ public class LineOfAccountingParser {
                 break;
             }
             String[] values = line.split("\\|");
-            LineOfAccounting code = processLineIntoLOA(values, columnNamesAndLocations, trdmLastUpdate);
+            LineOfAccounting code = processLineIntoLOA(values, columnNamesAndLocations, trdmLastUpdate, emailService);
 
             if (code != null) {
                 codes.add(code);
@@ -91,6 +93,11 @@ public class LineOfAccountingParser {
             row++;
         }
         logger.info("finished parsing every single line");
+        // If there is malformed LOA data send malformed data email
+        if (skippedLoaSysIds.size() > 0) {
+            logger.info("sending malformed LOA data email");
+            emailService.sendMalformedLOADataEmail(skippedLoaSysIds);
+        }
 
         scanner.close();
 
@@ -98,11 +105,15 @@ public class LineOfAccountingParser {
     }
 
     private LineOfAccounting processLineIntoLOA(String[] values, Map<String, Integer> columnHeaders,
-            XMLGregorianCalendar lastLoaUpdate)
+            XMLGregorianCalendar lastLoaUpdate, EmailService emailService)
             throws RuntimeException {
         // Check if value length does not align with columns
         if (values.length != columnHeaders.size()) {
             logger.info("TGET file row is malformed. This row of LOA data will not be parsed.");
+            // Add TAC_SYS_ID to skipped TACs array
+            skippedLoaSysIds.add((values[columnHeaders.get("LOA_SYS_ID")]));
+            logger.info("LOA data with LOA_SYS_ID: " + values[columnHeaders.get("LOA_SYS_ID")]
+                    + " skipped due to malformed data.");
             return null; // Skip this line
         }
         // Check if LOA is empty or if ROW_STS_CD is "DLT"

--- a/src/main/java/com/milmove/trdmlambda/milmove/util/LineOfAccountingParser.java
+++ b/src/main/java/com/milmove/trdmlambda/milmove/util/LineOfAccountingParser.java
@@ -45,7 +45,8 @@ public class LineOfAccountingParser {
             "LOA_FNCL_AR_ID", "LOA_SCRTY_COOP_CUST_CD", "LOA_END_FY_TX", "LOA_BG_FY_TX", "LOA_BGT_RSTR_CD",
             "LOA_BGT_SUB_ACT_CD", "ROW_STS_CD" };
 
-    public List<LineOfAccounting> parse(byte[] fileContent, XMLGregorianCalendar trdmLastUpdate, EmailService emailService)
+    public List<LineOfAccounting> parse(byte[] fileContent, XMLGregorianCalendar trdmLastUpdate,
+            EmailService emailService)
             throws RuntimeException {
         logger.info("beginning to parse LOA TGET data");
         List<LineOfAccounting> codes = new ArrayList<>();
@@ -53,7 +54,7 @@ public class LineOfAccountingParser {
         logger.info("skipping the first line and then gathering headers");
         String[] columnHeaders = scanner.nextLine().split("\\|"); // Skip first line and gather headers immediately
         logger.info("parsed these column headers from LOA attachment {}", Arrays.toString(columnHeaders));
-        
+
         // Sort both the expectedColumnNames and columnHeaders before comparing
         String[] sortedExpectedColumnNames = Arrays.copyOf(expectedColumnNames, expectedColumnNames.length);
         String[] sortedColumnHeaders = Arrays.copyOf(columnHeaders, columnHeaders.length);
@@ -65,7 +66,7 @@ public class LineOfAccountingParser {
                     Arrays.toString(columnHeaders), Arrays.toString(expectedColumnNames));
             throw new RuntimeException(message);
         }
-        
+
         // Map their order for when processing the LOA values properly
         for (int i = 0; i < columnHeaders.length; i++) {
             columnNamesAndLocations.put(columnHeaders[i], i);
@@ -119,6 +120,7 @@ public class LineOfAccountingParser {
         // Check if LOA is empty or if ROW_STS_CD is "DLT"
         if (values[columnHeaders.get("LOA_SYS_ID")].isEmpty()
                 || "DLT".equals(values[columnHeaders.get("ROW_STS_CD")])) {
+            logger.info("LOA is skipped because the data has an empty LOA_SYS_ID or ROW_STS_CD = DLT");
             return null; // Skip this line
         }
 

--- a/src/main/java/com/milmove/trdmlambda/milmove/util/LineOfAccountingParser.java
+++ b/src/main/java/com/milmove/trdmlambda/milmove/util/LineOfAccountingParser.java
@@ -120,7 +120,11 @@ public class LineOfAccountingParser {
         // Check if LOA is empty or if ROW_STS_CD is "DLT"
         if (values[columnHeaders.get("LOA_SYS_ID")].isEmpty()
                 || "DLT".equals(values[columnHeaders.get("ROW_STS_CD")])) {
-            logger.info("LOA is skipped because the data has an empty LOA_SYS_ID or ROW_STS_CD = DLT");
+            if (values[columnHeaders.get("LOA_SYS_ID")].isEmpty()) {
+                logger.info("LOA is skipped because the LOA has an empty LOA_SYS_ID");
+            } else if ("DLT".equals(values[columnHeaders.get("ROW_STS_CD")])) {
+                logger.info("LOA is skipped because the LOA column ROW_STS_CD = DLT");
+            }
             return null; // Skip this line
         }
 

--- a/src/main/java/com/milmove/trdmlambda/milmove/util/Trdm.java
+++ b/src/main/java/com/milmove/trdmlambda/milmove/util/Trdm.java
@@ -5,6 +5,7 @@ import com.milmove.trdmlambda.milmove.service.LastTableUpdateService;
 import ch.qos.logback.classic.Logger;
 
 import com.milmove.trdmlambda.milmove.service.DatabaseService;
+import com.milmove.trdmlambda.milmove.service.EmailService;
 import com.milmove.trdmlambda.milmove.service.GetTableService;
 
 import java.io.IOException;
@@ -180,8 +181,9 @@ public class Trdm {
                     case "transportation_accounting_codes":
                         // Parse the response attachment to get the codes
                         logger.info("parsing response back from TRDM getTable");
+                        EmailService malformedTACDataEmailService = new EmailService();
                         List<TransportationAccountingCode> codes = tacParser.parse(getTableResponse.getAttachment(),
-                                oneWeekLater);
+                                oneWeekLater, malformedTACDataEmailService);
 
                         // Generate list of TACs that needs to be updated. If TAC is in currentTacs then the
                         // TAC will be in updateTacs list because the TAC already exist
@@ -202,8 +204,9 @@ public class Trdm {
                     case "lines_of_accounting":
                         // Parse the response attachment to get the loas
                         logger.info("parsing response back from TRDM getTable");
+                        EmailService malformedLOADataEmailService = new EmailService();
                         List<LineOfAccounting> loas = loaParser.parse(getTableResponse.getAttachment(),
-                                oneWeekLater);
+                                oneWeekLater, malformedLOADataEmailService);
 
                         // Generate list of loas that needs to be updated. If loas are in curentLoas
                         // then the loa will be in updateLoas list because the loa already exist

--- a/src/test/java/com/milmove/trdmlambda/milmove/util/EmailServiceTest.java
+++ b/src/test/java/com/milmove/trdmlambda/milmove/util/EmailServiceTest.java
@@ -1,0 +1,58 @@
+package com.milmove.trdmlambda.milmove.util;
+
+import com.milmove.trdmlambda.milmove.service.EmailService;
+
+import jakarta.mail.MessagingException;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+
+import org.apache.cxf.common.i18n.Exception;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.milmove.trdmlambda.milmove.model.TransportationAccountingCode;
+
+import java.util.ArrayList;
+
+@ExtendWith(MockitoExtension.class)
+public class EmailServiceTest {
+
+    @Test // Test sendMalformedTACDataEmailTest()
+    void sendMalformedTACDataEmailTest() throws MessagingException {
+
+        EmailService emailService = new EmailService();
+        EmailService spyEmailService = spy(emailService);
+        ArrayList<String> codes = new ArrayList<String>();
+
+        codes.add("TEST");
+
+        // Skip the actual email send in a test
+        Mockito.doNothing().when(spyEmailService).send(any());
+        spyEmailService.sendMalformedTACDataEmail(codes);
+
+        verify(spyEmailService, times(1)).send(any());
+    }
+
+    @Test // Test sendMalformedLOADataEmailTest()
+    void sendMalformedLOADataEmailTest() throws MessagingException {
+
+        EmailService emailService = new EmailService();
+        EmailService spyEmailService = spy(emailService);
+        ArrayList<String> codes = new ArrayList<String>();
+        codes.add("TEST");
+
+        // Skip the actual email send in a test
+        Mockito.doNothing().when(spyEmailService).send(any());
+        spyEmailService.sendMalformedLOADataEmail(codes);
+
+        verify(spyEmailService, times(1)).send(any());
+    }
+}

--- a/src/test/java/com/milmove/trdmlambda/milmove/util/LineOfAccountingParserTest.java
+++ b/src/test/java/com/milmove/trdmlambda/milmove/util/LineOfAccountingParserTest.java
@@ -3,8 +3,10 @@ package com.milmove.trdmlambda.milmove.util;
 import org.junit.jupiter.api.Test;
 
 import com.milmove.trdmlambda.milmove.model.LineOfAccounting;
+import com.milmove.trdmlambda.milmove.service.EmailService;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -29,7 +31,8 @@ class LineOfAccountingParserTest {
         GregorianCalendar gregorianCalendar = new GregorianCalendar();
         XMLGregorianCalendar today = DatatypeFactory.newInstance().newXMLGregorianCalendar(gregorianCalendar);
 
-        List<LineOfAccounting> result = lineOfAccountingParser.parse(bytes, today);
+        EmailService emailService = mock(EmailService.class);
+        List<LineOfAccounting> result = lineOfAccountingParser.parse(bytes, today, emailService);
 
         assertNotNull(result);
         assertFalse(result.isEmpty());
@@ -106,8 +109,9 @@ class LineOfAccountingParserTest {
             
         GregorianCalendar gregorianCalendar = new GregorianCalendar();
         XMLGregorianCalendar today = DatatypeFactory.newInstance().newXMLGregorianCalendar(gregorianCalendar);
-
-        List<LineOfAccounting> result = lineOfAccountingParser.parse(bytes, today);
+        
+        EmailService emailService = mock(EmailService.class);
+        List<LineOfAccounting> result = lineOfAccountingParser.parse(bytes, today, emailService);
 
         // The parser in the case of parsing an incomplete pipe row will return the array of codes without the incomplete row
         assertNotNull(result);

--- a/src/test/java/com/milmove/trdmlambda/milmove/util/TransportationAccountingCodeParserTest.java
+++ b/src/test/java/com/milmove/trdmlambda/milmove/util/TransportationAccountingCodeParserTest.java
@@ -1,8 +1,11 @@
 package com.milmove.trdmlambda.milmove.util;
 
+import static org.mockito.Mockito.mock;
+
 import org.junit.jupiter.api.Test;
 
 import com.milmove.trdmlambda.milmove.model.TransportationAccountingCode;
+import com.milmove.trdmlambda.milmove.service.EmailService;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -28,8 +31,8 @@ class TransportationAccountingCodeParserTest {
 
         GregorianCalendar gregorianCalendar = new GregorianCalendar();
         XMLGregorianCalendar today = DatatypeFactory.newInstance().newXMLGregorianCalendar(gregorianCalendar);
-
-        List<TransportationAccountingCode> result = parser.parse(bytes, today);
+        EmailService emailService = mock(EmailService.class);
+        List<TransportationAccountingCode> result = parser.parse(bytes, today, emailService);
 
         assertNotNull(result);
         assertFalse(result.isEmpty());
@@ -74,8 +77,8 @@ class TransportationAccountingCodeParserTest {
             
         GregorianCalendar gregorianCalendar = new GregorianCalendar();
         XMLGregorianCalendar today = DatatypeFactory.newInstance().newXMLGregorianCalendar(gregorianCalendar);
-
-        List<TransportationAccountingCode> result = parser.parse(bytes, today);
+        EmailService emailService = mock(EmailService.class);
+        List<TransportationAccountingCode> result = parser.parse(bytes, today, emailService);
 
         // The parser in the case of parsing an incomplete pipe row will return the array of codes without the incomplete row
         assertNotNull(result);


### PR DESCRIPTION
Added logic to send an email when malformed TAC and LOA data is being skipped during parsing. Currently in an email I am just sending the TAC and LOA sys Id and can easily add on more information. Need to find a way to test this in staging where the actual email can be sent. Once tested i will also update the email sender, recipient, subject, and body as needed. Those are only HTML edits. Need to make sure email is actually going to be sent and received after this first round of implementation. Added logging to help a quick debug.