### PR TITLE
B 20145 automate tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,68 +1,93 @@
 version: 2.1
 
-references:
-  postgres: &postgres cimg/postgres:12.11
-
 executors:
-  trdm_compiler:
-    working_directory: ~/transcom/trdm-lambda
+  mymove_compiler:
     docker:
-      - image: *postgres
+      - image: milmove/circleci-docker:milmove-app-ab729849a08a773ea2557b19b67f378551d1ad3d
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
-        environment:
-          POSTGRES_PASSWORD: mysecretpassword
-          POSTGRES_DB: test_db
-          # use ramdisk for better performance
-          # https://circleci.com/docs/databases/#optimizing-postgresql-images
-          PGDATA: /dev/shm/pgdata/data
-        # override entrypoint/command for ramdisk
-        # this has been fixed in versions of postgres newer than 13.9
-        # https://github.com/CircleCI-Public/cimg-postgres/commit/3b320e26e4f187d0cd144efea1bc26cf5a2b68b0
-        # milmove is still on 12.11
-        entrypoint: /bin/bash
-        command: -c 'ln -s /dev/shm/pgdata/data /var/lib/postgresql/ && exec /usr/local/bin/docker-entrypoint.sh postgres'
-
-  trdm_tester:
-    docker:
-      - image: milmove/docker-mvn
-        auth:
-          password: $DOCKER_PASSWORD
-          username: $DOCKER_USERNAME
-      - image: *postgres
-        auth:
-          username: $DOCKERHUB_USERNAME
-          password: $DOCKERHUB_PASSWORD
-        environment:
-          POSTGRES_PASSWORD: mysecretpassword
-          POSTGRES_DB: test_db
-          # use ramdisk for better performance
-          # https://circleci.com/docs/databases/#optimizing-postgresql-images
-          PGDATA: /dev/shm/pgdata/data
-        # override entrypoint/command for ramdisk
-        # this has been fixed in versions of postgres newer than 13.9
-        # https://github.com/CircleCI-Public/cimg-postgres/commit/3b320e26e4f187d0cd144efea1bc26cf5a2b68b0
-        # milmove is still on 12.11
-        entrypoint: /bin/bash
-        command: -c 'ln -s /dev/shm/pgdata/data /var/lib/postgresql/ && exec /usr/local/bin/docker-entrypoint.sh postgres'
 
 jobs:
-  test_setup:
-    executor: trdm_compiler
+  setup_tests:
+    executor: mymove_compiler
+    environment:
+      GOPATH: /home/circleci/go
+      APPLICATION: app
+      DB_PASSWORD: mysecretpassword
+      DB_USER_LOW_PRIV: crud
+      DB_PASSWORD_LOW_PRIV: mysecretpassword
+      DB_USER: postgres
+      DB_HOST: localhost
+      DB_PORT_TEST: 5433 # Mymove's makefile will convert this to 5432 for CircleCI
+      DB_PORT: 5432
+      DB_NAME: test_db
+      DB_NAME_TEST: test_db
+      DTOD_USE_MOCK: 'true'
+      MIGRATION_MANIFEST: 'migrations/app/migrations_manifest.txt'
+      MIGRATION_PATH: 'file://migrations/app/schema;file://migrations/app/secure'
+      EIA_KEY: db2522a43820268a41a802a16ae9fd26 # dummy key generated with openssl rand -hex 16
+      ENV: test
+      ENVIRONMENT: test
+      SERVER_REPORT: 1
+      COVERAGE: 1
+      SERVE_API_INTERNAL: 'true'
+      OKTA_CUSTOMER_CLIENT_ID: 1q2w3e4r5t6y7u8i9o
+      OKTA_ADMIN_CLIENT_ID: AQ1SW2DE3FR4G5
+      OKTA_OFFICE_CLIENT_ID: 9f9f9s8s90gig9
+      OKTA_API_KEY: notrealapikey8675309
+      OKTA_OFFICE_GROUP_ID: notrealgroupId
+      OKTA_CUSTOMER_GROUP_ID: notrealcustomergroupId
     steps:
       - run:
           name: Checkout mymove repository
-          command: |
-            git clone https://github.com/transcom/mymove.git ~/mymove
+          command: git clone https://github.com/transcom/mymove.git ~/mymove
       - run:
-          name: Build and run test db
+          name: Create mymove binary
+          command: | 
+            cd ~/mymove
+            make bin/milmove
+      # Attempt to bypass CircleCI CLI docker version issues by using the old version https://circleci.com/docs/building-docker-images/#docker-version
+      # See ongoing issue here https://discuss.circleci.com/t/circleci-cli-error-response-from-daemon-invalid-uts-mode/48081/10
+      - setup_remote_docker:
+          version: 20.10.24
+      - run:
+          name: Ensure the PostgreSQL remote container is removed if something prevented shutdown previously
+          command: |
+            sudo docker rm -f setup_tests_postgres_container || true
+      - run:
+          name: Start PostgreSQL remote container
+          command: |
+            # Attempt force PostgreSQL to run on localhost, otherwise it defaults to IPv4 `0.0.0.0` and IPv6 `::`
+            # This container should shut down on its own on exit
+            sudo docker run --platform linux/amd64 --rm -d --name setup_tests_postgres_container -e POSTGRES_PASSWORD=mysecretpassword -e POSTGRES_DB=test_db -v /dev/shm/pgdata:/var/lib/postgresql/data cimg/postgres:12.11 -c 'listen_addresses=127.0.0.1,::1'
+      - run:
+          name: List docker containers
+          command: |
+            sudo docker ps -a
+      - run:
+          name: List remote test container logs
+          command: |
+            sudo docker logs setup_tests_postgres_container
+      - run:
+          name: Wait for PostgreSQL to be ready on remote test container
+          command: |
+            until sudo docker exec setup_tests_postgres_container pg_isready -h localhost -p 5432 -U postgres; do
+              echo "Waiting for PostgreSQL on localhost:5432..."
+              sleep 2
+            done
+      - run:
+          name: Migrate the test db on the remote test container
           command: |
             cd ~/mymove
-            make db_test_run 
+            make db_test_run
+      - run:
+          name: Stop PostgreSQL remote container
+          command: sudo docker stop setup_tests_postgres_container
+          when: always # If a previous step fails make sure that it gets closed no matter what
 
   mvn_test:
-    executor: trdm_tester
+    executor: mymove_compiler
     steps:
       - checkout
       - run:
@@ -78,7 +103,7 @@ jobs:
             - server_test_job_id.env
 
   sam_package:
-    executor: trdm_tester
+    executor: mymove_compiler
     steps:
       - checkout
       - run:
@@ -121,21 +146,28 @@ jobs:
 workflows:
   build:
     jobs:
-      - test_setup
-      - mvn_test
+      - setup_tests
+      - mvn_test:
+          requires:
+            - setup_tests
       - sam_package:
           requires:
-            - test_setup
             - mvn_test
           context:
             - org-global
 
   release:
     jobs:
-      - test_setup
-      - mvn_test
-      - sam_package
+      - setup_tests
+      - mvn_test:
+          requires:
+            - setup_tests
+      - sam_package:
+          requires:
+            - mvn_test
       - upload_release_to_github:
+          requires:
+            - sam_package
           context:
             - org-global
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,10 +7,6 @@ executors:
   trdm_compiler:
     working_directory: ~/transcom/trdm-lambda
     docker:
-      - image: milmove/circleci-docker:milmove-app-ab729849a08a773ea2557b19b67f378551d1ad3d
-        auth:
-          username: $DOCKERHUB_USERNAME
-          password: $DOCKERHUB_PASSWORD
       - image: *postgres
         auth:
           username: $DOCKERHUB_USERNAME
@@ -144,6 +140,6 @@ workflows:
             - org-global
           filters:
             branches:
-              ignore: /^.*/
+              only: main
             tags:
               only: /^v.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,10 +84,11 @@ jobs:
       - run:
           name: Wait for PostgreSQL to be ready on remote test container
           command: |
+            timeout 60 bash -c '
             until sudo docker exec setup_tests_postgres_container pg_isready -h ${DB_HOST} -p 5432 -U postgres; do
               echo "Waiting for PostgreSQL on ${DB_HOST}:5432..."
               sleep 2
-            done
+            done' || echo "Timed out waiting for PostgreSQL on ${DB_HOST}:5432"
       - run:
           name: Create the test db without mymove binary for faster debugging
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -138,10 +138,6 @@ jobs:
           command: sudo docker stop setup_tests_postgres_container
           when: always
       - run:
-          name: Stop Maven testing remote container
-          command: sudo docker stop maven_test_container
-          when: always
-      - run:
           name: Disconnect host from docker network
           command: sudo docker network disconnect nested_docker_network $(hostname)
           when: always

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -160,7 +160,7 @@ jobs:
           name: Build
           command: scripts/build
 
-  upload_release_to_github:
+  release:
     executor: tls_small
     steps:
       - checkout
@@ -196,7 +196,7 @@ workflows:
       - build:
           requires:
             - test
-      - upload_release_to_github:
+      - release:
           requires:
             - build
           context:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,14 +39,16 @@ jobs:
       OKTA_OFFICE_GROUP_ID: notrealgroupId
       OKTA_CUSTOMER_GROUP_ID: notrealcustomergroupId
     steps:
-      - run:
-          name: Checkout mymove repository
-          command: git clone https://github.com/transcom/mymove.git ~/mymove
-      - run:
-          name: Create mymove binary
-          command: | 
-            cd ~/mymove
-            make bin/milmove
+      # Temp skip these 2 for faster debugging
+      # - run:
+      #     name: Checkout mymove repository
+      #     command: git clone https://github.com/transcom/mymove.git ~/mymove
+      # - run:
+      #     name: Create mymove binary
+      #     command: | 
+      #       cd ~/mymove
+      #       make bin/milmove
+      - checkout # Checkout our repo for faster debugging (Just the wait-for-db script)
       # Attempt to bypass CircleCI CLI docker version issues by using the old version https://circleci.com/docs/building-docker-images/#docker-version
       # See ongoing issue here https://discuss.circleci.com/t/circleci-cli-error-response-from-daemon-invalid-uts-mode/48081/10
       - setup_remote_docker:
@@ -76,11 +78,19 @@ jobs:
               echo "Waiting for PostgreSQL on localhost:5432..."
               sleep 2
             done
+      # Temp skipping for faster debugging
+      # - run:
+      #     name: Migrate the test db on the remote test container
+      #     command: |
+      #       cd ~/mymove
+      #       make db_test_run
       - run:
-          name: Migrate the test db on the remote test container
+          name: Create the test db without mymove binary for faster debugging
           command: |
-            cd ~/mymove
-            make db_test_run
+            echo "Create the ${DB_NAME_TEST} database..."
+            ls scripts/
+            DB_NAME=postgres DB_PORT=${DB_PORT_TEST} ./scripts/wait-for-db && \
+            createdb -p ${DB_PORT_TEST} -h ${DB_HOST} -U postgres ${DB_NAME_TEST} || true
       - run:
           name: Stop PostgreSQL remote container
           command: sudo docker stop setup_tests_postgres_container

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,20 +1,88 @@
 version: 2.1
 
-jobs:
-  build:
+references:
+  postgres: &postgres cimg/postgres:12.11
+
+executors:
+  trdm_compiler:
+    working_directory: ~/transcom/trdm-lambda
+    docker:
+      - image: milmove/circleci-docker:milmove-app-ab729849a08a773ea2557b19b67f378551d1ad3d
+        auth:
+          username: $DOCKERHUB_USERNAME
+          password: $DOCKERHUB_PASSWORD
+      - image: *postgres
+        auth:
+          username: $DOCKERHUB_USERNAME
+          password: $DOCKERHUB_PASSWORD
+        environment:
+          POSTGRES_PASSWORD: mysecretpassword
+          POSTGRES_DB: test_db
+          # use ramdisk for better performance
+          # https://circleci.com/docs/databases/#optimizing-postgresql-images
+          PGDATA: /dev/shm/pgdata/data
+        # override entrypoint/command for ramdisk
+        # this has been fixed in versions of postgres newer than 13.9
+        # https://github.com/CircleCI-Public/cimg-postgres/commit/3b320e26e4f187d0cd144efea1bc26cf5a2b68b0
+        # milmove is still on 12.11
+        entrypoint: /bin/bash
+        command: -c 'ln -s /dev/shm/pgdata/data /var/lib/postgresql/ && exec /usr/local/bin/docker-entrypoint.sh postgres'
+
+  trdm_tester:
     docker:
       - image: milmove/docker-mvn
         auth:
           password: $DOCKER_PASSWORD
           username: $DOCKER_USERNAME
+      - image: *postgres
+        auth:
+          username: $DOCKERHUB_USERNAME
+          password: $DOCKERHUB_PASSWORD
         environment:
-          TEST_DB_HOST: localhost
-          TEST_DB_NAME: test_db
-          TEST_DB_USER: postgres
-          TEST_DB_PORT: 5433
-          TEST_DB_PASSWORD: mysecretpassword
-          TEST_DB_URL: jdbc:postgresql://localhost:5433/test_db?user=postgres&password=mysecretpassword
+          POSTGRES_PASSWORD: mysecretpassword
+          POSTGRES_DB: test_db
+          # use ramdisk for better performance
+          # https://circleci.com/docs/databases/#optimizing-postgresql-images
+          PGDATA: /dev/shm/pgdata/data
+        # override entrypoint/command for ramdisk
+        # this has been fixed in versions of postgres newer than 13.9
+        # https://github.com/CircleCI-Public/cimg-postgres/commit/3b320e26e4f187d0cd144efea1bc26cf5a2b68b0
+        # milmove is still on 12.11
+        entrypoint: /bin/bash
+        command: -c 'ln -s /dev/shm/pgdata/data /var/lib/postgresql/ && exec /usr/local/bin/docker-entrypoint.sh postgres'
 
+jobs:
+  pre_test:
+    executor: trdm_compiler
+    steps:
+      - run:
+          name: Checkout mymove repository
+          command: |
+            git clone https://github.com/transcom/mymove.git ~/mymove
+      - run:
+          name: Build and run test db
+          command: |
+            cd ~/mymove
+            make db_test_run 
+
+  mvn_test:
+    executor: trdm_tester
+    steps:
+      - checkout
+      - run:
+          name: Copy Workflow Job ID to file
+          command: |
+            echo "export SERVER_TEST_JOB_ID=$CIRCLE_WORKFLOW_JOB_ID" >> server_test_job_id.env
+      - run:
+          name: Maven tests
+          command: mvn test
+      - persist_to_workspace:
+          root: .
+          paths:
+            - server_test_job_id.env
+
+  build:
+    executor: trdm_tester
     steps:
       - checkout
       - run:
@@ -23,6 +91,7 @@ jobs:
       - run:
           name: Build
           command: scripts/build
+
   release:
     docker:
       - image: milmove/docker-mvn
@@ -61,15 +130,23 @@ jobs:
       - store_artifacts:
           path: workspace/*.txt
           destination: artifacts
+
 workflows:
-  version: 2
-  build:
+  build_zip_files:
     jobs:
+      - pre_test
+      - mvn_test
       - build:
+          requires:
+            - pre_test
+            - mvn_test
           context:
             - org-global
-  release:
+
+  release_to_github:
     jobs:
+      - mvn_test
+      - build
       - release:
           context:
             - org-global

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,7 @@ executors:
         command: -c 'ln -s /dev/shm/pgdata/data /var/lib/postgresql/ && exec /usr/local/bin/docker-entrypoint.sh postgres'
 
 jobs:
-  pre_test:
+  test_setup:
     executor: trdm_compiler
     steps:
       - run:
@@ -81,18 +81,15 @@ jobs:
           paths:
             - server_test_job_id.env
 
-  build:
+  sam_package:
     executor: trdm_tester
     steps:
       - checkout
       - run:
-          name: Tests
-          command: mvn test
-      - run:
           name: Build
           command: scripts/build
 
-  release:
+  upload_release_to_github:
     docker:
       - image: milmove/docker-mvn
         auth:
@@ -100,12 +97,6 @@ jobs:
           username: $DOCKER_USERNAME
     steps:
       - checkout
-      - run:
-          name: Tests
-          command: mvn test
-      - run:
-          name: Build
-          command: scripts/build
       - run:
           name: Release
           command: scripts/release $CIRCLE_PROJECT_USERNAME $CIRCLE_PROJECT_REPONAME << pipeline.git.tag >>
@@ -132,22 +123,23 @@ jobs:
           destination: artifacts
 
 workflows:
-  build_zip_files:
+  build:
     jobs:
-      - pre_test
+      - test_setup
       - mvn_test
-      - build:
+      - sam_package:
           requires:
-            - pre_test
+            - test_setup
             - mvn_test
           context:
             - org-global
 
-  release_to_github:
+  release:
     jobs:
+      - test_setup
       - mvn_test
-      - build
-      - release:
+      - sam_package
+      - upload_release_to_github:
           context:
             - org-global
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,15 +1,35 @@
 version: 2.1
 
+references:
+  circleci-docker: &circleci-docker milmove/circleci-docker:milmove-app-ab729849a08a773ea2557b19b67f378551d1ad3d
+
 executors:
+  # Additional docker images are utilized without executors further below
+  # It was done to circumvent known CircleCI local CLI issues to allow
+  # local testing instead of testing live
+  # See the following
+  # - https://discuss.circleci.com/t/circleci-cli-error-response-from-daemon-invalid-uts-mode/48081/10
+  # - https://github.com/CircleCI-Public/circleci-cli/issues/970
+  # - https://circleci.com/docs/building-docker-images/#docker-version 
+  # 20.10.24 is listed as the deprecated CircleCI docker, but is also the last working version of docker
+  # that didn't have this issue hence why we use remote docker containers
   mymove_compiler:
     docker:
-      - image: milmove/circleci-docker:milmove-app-ab729849a08a773ea2557b19b67f378551d1ad3d
+      - image: *circleci-docker
+        auth:
+          username: $DOCKERHUB_USERNAME
+          password: $DOCKERHUB_PASSWORD
+  tls_small:
+    resource_class: small
+    working_directory: ~/transcom/mymove
+    docker:
+      - image: *circleci-docker
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
 
 jobs:
-  setup_tests:
+  test:
     executor: mymove_compiler
     environment:
       GOPATH: /home/circleci/go
@@ -39,7 +59,7 @@ jobs:
       OKTA_OFFICE_GROUP_ID: notrealgroupId
       OKTA_CUSTOMER_GROUP_ID: notrealcustomergroupId
     steps:
-      # Temp skip these 2 for faster debugging
+      # Temp skip these for faster debugging
       # - run:
       #     name: Checkout mymove repository
       #     command: git clone https://github.com/transcom/mymove.git ~/mymove
@@ -48,6 +68,11 @@ jobs:
       #     command: | 
       #       cd ~/mymove
       #       make bin/milmove
+      # - run:
+      #     name: Migrate the test db on the remote test container
+      #     command: |
+      #       cd ~/mymove
+      #       make db_test_run
       - checkout # Checkout our repo for faster debugging (Just the wait-for-db script)
       # Attempt to bypass CircleCI CLI docker version issues by using the old version https://circleci.com/docs/building-docker-images/#docker-version
       # See ongoing issue here https://discuss.circleci.com/t/circleci-cli-error-response-from-daemon-invalid-uts-mode/48081/10
@@ -55,8 +80,7 @@ jobs:
           version: 20.10.24
       - run:
           name: Ensure the PostgreSQL remote container is removed if something prevented shutdown previously
-          command: |
-            sudo docker rm -f setup_tests_postgres_container || true
+          command: sudo docker rm -f setup_tests_postgres_container || true
       - run:
           name: Start new docker network for port access
           command: sudo docker network create nested_docker_network
@@ -65,25 +89,7 @@ jobs:
           command: sudo docker network connect nested_docker_network $(hostname)
       - run:
           name: Start PostgreSQL remote container
-          command: |
-            # Attempt force PostgreSQL to run on localhost, otherwise it defaults to IPv4 `0.0.0.0` and IPv6 `::`
-            # This container should shut down on its own on exit
-            sudo docker run --network nested_docker_network --network-alias postgres_db_container --platform linux/amd64 --rm -d --name setup_tests_postgres_container -e POSTGRES_PASSWORD=mysecretpassword -e POSTGRES_DB=test_db -v /dev/shm/pgdata:/var/lib/postgresql/data cimg/postgres:12.11 -c 'listen_addresses=*'
-      - run:
-          name: List docker containers
-          command: |
-            sudo docker ps -a
-      - run:
-          name: List remote test container logs
-          command: |
-            sudo docker logs setup_tests_postgres_container
-
-      # Temp skipping for faster debugging
-      # - run:
-      #     name: Migrate the test db on the remote test container
-      #     command: |
-      #       cd ~/mymove
-      #       make db_test_run
+          command: sudo docker run --network nested_docker_network --network-alias postgres_db_container --rm -d --name setup_tests_postgres_container -e POSTGRES_PASSWORD=mysecretpassword -e POSTGRES_DB=test_db -v /dev/shm/pgdata:/var/lib/postgresql/data cimg/postgres:12.11 -c 'listen_addresses=*'
       - run:
           name: Get PostgreSQL container IP address
           command: |
@@ -97,23 +103,38 @@ jobs:
               sleep 2
             done
       - run:
-          name: Check PostgreSQL container logs
-          command: sudo docker logs setup_tests_postgres_container
-      - run:
-          name: Check PostgreSQL configuration
-          command: |
-            sudo docker exec setup_tests_postgres_container cat /var/lib/postgresql/data/postgresql.conf | grep listen_addresses
-            sudo docker exec setup_tests_postgres_container cat /var/lib/postgresql/data/pg_hba.conf
-      - run:
           name: Create the test db without mymove binary for faster debugging
           command: |
             echo "Create the ${DB_NAME_TEST} database..."
             DB_NAME=postgres DB_PORT=${DB_PORT_TEST} ./scripts/wait-for-db && \
-            createdb -p ${DB_PORT_TEST} -h postgres_db_container -U postgres ${DB_NAME_TEST} || true
+            createdb -p ${DB_PORT_TEST} -h ${DB_HOST} -U postgres ${DB_NAME_TEST} || true
+      - run:
+          name: Create the Maven test container while streaming the TRDM files to it for testing
+          command: |
+            # Tarball the current directory with the TRDM project files and send it to the maven_test_container
+            # The maven_test_container receives it as input rather than a volume
+            # This is important to allow local pipelines to run properly to avoid host machine volume mounting access issues
+            # This will also create the maven_test_container with the milmove/docker-mvn image
+            tar -czf - . | sudo docker run --network nested_docker_network --name maven_test_container --rm -i milmove/docker-mvn bash -c "
+            # Execute the following commands inside of maven_test_container
+            # Create a directory to store the tarball in the maven container
+            mkdir -p /tmp/trdm
+            # Extract the tarball from the input stream and place it into our directory
+            tar -xzf - -C /tmp/trdm
+            cd /tmp/trdm
+            # Set the test db to read from the postgres container in our docker network
+            # Create and feed in the test_db_url
+            export TEST_DB_URL='jdbc:postgresql://${DB_HOST}:${DB_PORT_TEST}/${DB_NAME_TEST}?user=${DB_USER}&password=${DB_PASSWORD}'
+            mvn test | tee /tmp/mvn_test_output.log"
+            # TODO: Verify successful testing
       - run:
           name: Stop PostgreSQL remote container
           command: sudo docker stop setup_tests_postgres_container
-          when: always # If a previous step fails make sure that it gets closed no matter what
+          when: always
+      - run:
+          name: Stop Maven testing remote container
+          command: sudo docker stop maven_test_container
+          when: always
       - run:
           name: Disconnect host from docker network
           command: sudo docker network disconnect nested_docker_network $(hostname)
@@ -122,22 +143,6 @@ jobs:
           name: Stop docker network
           command: sudo docker network rm nested_docker_network
           when: always
-
-  mvn_test:
-    executor: mymove_compiler
-    steps:
-      - checkout
-      - run:
-          name: Copy Workflow Job ID to file
-          command: |
-            echo "export SERVER_TEST_JOB_ID=$CIRCLE_WORKFLOW_JOB_ID" >> server_test_job_id.env
-      - run:
-          name: Maven tests
-          command: mvn test
-      - persist_to_workspace:
-          root: .
-          paths:
-            - server_test_job_id.env
 
   sam_package:
     executor: mymove_compiler
@@ -148,11 +153,7 @@ jobs:
           command: scripts/build
 
   upload_release_to_github:
-    docker:
-      - image: milmove/docker-mvn
-        auth:
-          password: $DOCKER_PASSWORD
-          username: $DOCKER_USERNAME
+    executor: tls_small
     steps:
       - checkout
       - run:
@@ -183,25 +184,19 @@ jobs:
 workflows:
   build:
     jobs:
-      - setup_tests
-      - mvn_test:
-          requires:
-            - setup_tests
+      - test
       - sam_package:
           requires:
-            - mvn_test
+            - test
           context:
             - org-global
 
   release:
     jobs:
-      - setup_tests
-      - mvn_test:
-          requires:
-            - setup_tests
+      - test
       - sam_package:
           requires:
-            - mvn_test
+            - test
       - upload_release_to_github:
           requires:
             - sam_package
@@ -210,5 +205,3 @@ workflows:
           filters:
             branches:
               only: main
-            tags:
-              only: /^v.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,6 +61,9 @@ jobs:
           name: Start new docker network for port access
           command: sudo docker network create nested_docker_network
       - run:
+          name: Join the host container on the network
+          command: sudo docker network connect nested_docker_network $(hostname)
+      - run:
           name: Start PostgreSQL remote container
           command: |
             # Attempt force PostgreSQL to run on localhost, otherwise it defaults to IPv4 `0.0.0.0` and IPv6 `::`
@@ -111,6 +114,10 @@ jobs:
           name: Stop PostgreSQL remote container
           command: sudo docker stop setup_tests_postgres_container
           when: always # If a previous step fails make sure that it gets closed no matter what
+      - run:
+          name: Disconnect host from docker network
+          command: sudo docker network disconnect nested_docker_network $(hostname)
+          when: always
       - run:
           name: Stop docker network
           command: sudo docker network rm nested_docker_network

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,6 +27,13 @@ executors:
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
+  trdm_compiler:
+    docker:
+      - image: milmove/docker-mvn
+        auth:
+          password: $DOCKER_PASSWORD
+          username: $DOCKER_USERNAME
+
 
 jobs:
   test:
@@ -145,8 +152,8 @@ jobs:
           command: sudo docker network rm nested_docker_network
           when: always
 
-  sam_package:
-    executor: mymove_compiler
+  build:
+    executor: trdm_compiler
     steps:
       - checkout
       - run:
@@ -183,24 +190,15 @@ jobs:
           destination: artifacts
 
 workflows:
-  build:
+  lambda:
     jobs:
       - test
-      - sam_package:
-          requires:
-            - test
-          context:
-            - org-global
-
-  release:
-    jobs:
-      - test
-      - sam_package:
+      - build:
           requires:
             - test
       - upload_release_to_github:
           requires:
-            - sam_package
+            - build
           context:
             - org-global
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,7 +112,7 @@ jobs:
       # Now that the test_db is setup and migrated, the next step is to setup the maven testing container
       # to run tests against said test_dbß
       - run:
-          name: Create the Maven test container while streaming the TRDM files to it for testing
+          name: Create and test the Maven container
           command: |
             # Tarball the current directory with the TRDM project files and send it to the maven_test_container
             # The maven_test_container receives it as input rather than a volume
@@ -131,8 +131,7 @@ jobs:
             export TEST_DB_PORT=${DB_PORT_TEST}
             export TEST_DB_NAME=${DB_NAME_TEST}
             export TEST_DB_USER=${DB_USER}
-            mvn test | tee /tmp/mvn_test_output.log"
-            # TODO: Verify successful testing
+            mvn test"
       - run:
           name: Stop PostgreSQL remote container
           command: sudo docker stop setup_tests_postgres_container

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,7 +68,7 @@ jobs:
           name: Ensure the PostgreSQL remote container is removed if something prevented shutdown previously
           command: sudo docker rm -f setup_tests_postgres_container || true
       - run:
-          name: Start new docker network for port access
+          name: Start new docker network
           command: sudo docker network create nested_docker_network
       - run:
           name: Join the host container on the network

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,8 +18,8 @@ jobs:
       DB_USER_LOW_PRIV: crud
       DB_PASSWORD_LOW_PRIV: mysecretpassword
       DB_USER: postgres
-      DB_HOST: localhost
-      DB_PORT_TEST: 5433 # Mymove's makefile will convert this to 5432 for CircleCI
+      DB_HOST: postgres_db_container
+      DB_PORT_TEST: 5432 # Mymove's makefile will convert this to 5432 for CircleCI
       DB_PORT: 5432
       DB_NAME: test_db
       DB_NAME_TEST: test_db
@@ -58,11 +58,14 @@ jobs:
           command: |
             sudo docker rm -f setup_tests_postgres_container || true
       - run:
+          name: Start new docker network for port access
+          command: sudo docker network create nested_docker_network
+      - run:
           name: Start PostgreSQL remote container
           command: |
             # Attempt force PostgreSQL to run on localhost, otherwise it defaults to IPv4 `0.0.0.0` and IPv6 `::`
             # This container should shut down on its own on exit
-            sudo docker run --platform linux/amd64 --rm -d --name setup_tests_postgres_container -e POSTGRES_PASSWORD=mysecretpassword -e POSTGRES_DB=test_db -v /dev/shm/pgdata:/var/lib/postgresql/data cimg/postgres:12.11 -c 'listen_addresses=127.0.0.1,::1'
+            sudo docker run --network nested_docker_network --network-alias postgres_db_container --platform linux/amd64 --rm -d --name setup_tests_postgres_container -e POSTGRES_PASSWORD=mysecretpassword -e POSTGRES_DB=test_db -v /dev/shm/pgdata:/var/lib/postgresql/data cimg/postgres:12.11 -c 'listen_addresses=*'
       - run:
           name: List docker containers
           command: |
@@ -71,13 +74,7 @@ jobs:
           name: List remote test container logs
           command: |
             sudo docker logs setup_tests_postgres_container
-      - run:
-          name: Wait for PostgreSQL to be ready on remote test container
-          command: |
-            until sudo docker exec setup_tests_postgres_container pg_isready -h localhost -p 5432 -U postgres; do
-              echo "Waiting for PostgreSQL on localhost:5432..."
-              sleep 2
-            done
+
       # Temp skipping for faster debugging
       # - run:
       #     name: Migrate the test db on the remote test container
@@ -85,16 +82,39 @@ jobs:
       #       cd ~/mymove
       #       make db_test_run
       - run:
+          name: Get PostgreSQL container IP address
+          command: |
+            export DB_HOST=$(sudo docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' setup_tests_postgres_container)
+            echo "DB_HOST=${DB_HOST}" | tee -a $BASH_ENV
+      - run:
+          name: Wait for PostgreSQL to be ready on remote test container
+          command: |
+            until sudo docker exec setup_tests_postgres_container pg_isready -h ${DB_HOST} -p 5432 -U postgres; do
+              echo "Waiting for PostgreSQL on ${DB_HOST}:5432..."
+              sleep 2
+            done
+      - run:
+          name: Check PostgreSQL container logs
+          command: sudo docker logs setup_tests_postgres_container
+      - run:
+          name: Check PostgreSQL configuration
+          command: |
+            sudo docker exec setup_tests_postgres_container cat /var/lib/postgresql/data/postgresql.conf | grep listen_addresses
+            sudo docker exec setup_tests_postgres_container cat /var/lib/postgresql/data/pg_hba.conf
+      - run:
           name: Create the test db without mymove binary for faster debugging
           command: |
             echo "Create the ${DB_NAME_TEST} database..."
-            ls scripts/
             DB_NAME=postgres DB_PORT=${DB_PORT_TEST} ./scripts/wait-for-db && \
-            createdb -p ${DB_PORT_TEST} -h ${DB_HOST} -U postgres ${DB_NAME_TEST} || true
+            createdb -p ${DB_PORT_TEST} -h postgres_db_container -U postgres ${DB_NAME_TEST} || true
       - run:
           name: Stop PostgreSQL remote container
           command: sudo docker stop setup_tests_postgres_container
           when: always # If a previous step fails make sure that it gets closed no matter what
+      - run:
+          name: Stop docker network
+          command: sudo docker network rm nested_docker_network
+          when: always
 
   mvn_test:
     executor: mymove_compiler

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,19 +60,6 @@ jobs:
       OKTA_CUSTOMER_GROUP_ID: notrealcustomergroupId
     steps:
       # Temp skip these for faster debugging
-      # - run:
-      #     name: Checkout mymove repository
-      #     command: git clone https://github.com/transcom/mymove.git ~/mymove
-      # - run:
-      #     name: Create mymove binary
-      #     command: | 
-      #       cd ~/mymove
-      #       make bin/milmove
-      # - run:
-      #     name: Migrate the test db on the remote test container
-      #     command: |
-      #       cd ~/mymove
-      #       make db_test_run
       - checkout # Checkout our repo for faster debugging (Just the wait-for-db script)
       # Attempt to bypass CircleCI CLI docker version issues by using the old version https://circleci.com/docs/building-docker-images/#docker-version
       # See ongoing issue here https://discuss.circleci.com/t/circleci-cli-error-response-from-daemon-invalid-uts-mode/48081/10
@@ -108,6 +95,22 @@ jobs:
             echo "Create the ${DB_NAME_TEST} database..."
             DB_NAME=postgres DB_PORT=${DB_PORT_TEST} ./scripts/wait-for-db && \
             createdb -p ${DB_PORT_TEST} -h ${DB_HOST} -U postgres ${DB_NAME_TEST} || true
+      # Now that we have our test db, the next step is to get MyMove configured and migrate it
+      - run:
+          name: Checkout mymove repository
+          command: git clone https://github.com/transcom/mymove.git ~/mymove
+      - run:
+          name: Create mymove binary
+          command: | 
+            cd ~/mymove
+            make bin/milmove
+      - run:
+          name: Migrate the PostgreSQL container's test db with MyMove migrations
+          command: |
+            cd ~/mymove
+            make db_test_migrate_standalone
+      # Now that the test_db is setup and migrated, the next step is to setup the maven testing container
+      # to run tests against said test_dbß
       - run:
           name: Create the Maven test container while streaming the TRDM files to it for testing
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,8 +59,7 @@ jobs:
       OKTA_OFFICE_GROUP_ID: notrealgroupId
       OKTA_CUSTOMER_GROUP_ID: notrealcustomergroupId
     steps:
-      # Temp skip these for faster debugging
-      - checkout # Checkout our repo for faster debugging (Just the wait-for-db script)
+      - checkout
       # Attempt to bypass CircleCI CLI docker version issues by using the old version https://circleci.com/docs/building-docker-images/#docker-version
       # See ongoing issue here https://discuss.circleci.com/t/circleci-cli-error-response-from-daemon-invalid-uts-mode/48081/10
       - setup_remote_docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,7 +97,7 @@ jobs:
               sleep 2
             done' || echo "Timed out waiting for PostgreSQL on ${DB_HOST}:5432"
       - run:
-          name: Create the test db without mymove binary for faster debugging
+          name: Create the test db without mymove binary
           command: |
             echo "Create the ${DB_NAME_TEST} database..."
             DB_NAME=postgres DB_PORT=${DB_PORT_TEST} ./scripts/wait-for-db && \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,6 +18,9 @@ jobs:
     steps:
       - checkout
       - run:
+          name: Tests
+          command: mvn test
+      - run:
           name: Build
           command: scripts/build
   release:
@@ -28,6 +31,9 @@ jobs:
           username: $DOCKER_USERNAME
     steps:
       - checkout
+      - run:
+          name: Tests
+          command: mvn test
       - run:
           name: Build
           command: scripts/build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -126,8 +126,11 @@ jobs:
             tar -xzf - -C /tmp/trdm
             cd /tmp/trdm
             # Set the test db to read from the postgres container in our docker network
-            # Create and feed in the test_db_url
             export TEST_DB_URL='jdbc:postgresql://${DB_HOST}:${DB_PORT_TEST}/${DB_NAME_TEST}?user=${DB_USER}&password=${DB_PASSWORD}'
+            export TEST_DB_HOST=${DB_HOST}
+            export TEST_DB_PORT=${DB_PORT_TEST}
+            export TEST_DB_NAME=${DB_NAME_TEST}
+            export TEST_DB_USER=${DB_USER}
             mvn test | tee /tmp/mvn_test_output.log"
             # TODO: Verify successful testing
       - run:

--- a/scripts/build
+++ b/scripts/build
@@ -6,8 +6,7 @@ set -eu -o pipefail
 echo "Packaging..."
 
 # Build via sam
-# Tests have been disabled during the build because more work needs to be completed to automate the pipelines for trdm
-# sam build // This should be reinstated in B-20145 under E-05306
+# Tests are run before the build step
 MAVEN_OPTS="-DskipTests=true" sam build
 
 # Zip requires `cd` because if not it will compile the relative paths
@@ -33,5 +32,5 @@ cd ../../../
 echo "Packaging complete, saving as artifact."
 echo "Calculating checksum."
 sha512sum deployment-package.stg.zip > stg-checksums.txt
-sha512sum deployment-package.prd.zip > prd-checksums.txt
+sha512sum deployment-package.prd.zip > prd-checksums.txt 
 ls

--- a/scripts/wait-for-db
+++ b/scripts/wait-for-db
@@ -12,7 +12,7 @@ db_name="${DB_NAME:-postgres}"
 db_port="${DB_PORT:-5432}"
 retries=0
 timeout="${DB_TIMEOUT:-20}"
-db_check_command="psql postgres://${db_user}:${db_password}@${db_host}:${db_port}/${db_name} -c 'select 1;' > /dev/null 2>&1"
+db_check_command="psql postgres://${db_user}:${db_password}@${db_host}:${db_port}/${db_name} -c 'select 1;'"
 
 echo "> ${db_check_command}"
 echo -n "Checking for database connectivity.."

--- a/scripts/wait-for-db
+++ b/scripts/wait-for-db
@@ -1,0 +1,30 @@
+#! /usr/bin/env bash
+# This script waits for an available database connection, or until a timeout is
+# reached. Useful to test database connectivity, or wait for local Docker
+# instances to spin up.
+
+set -eu -o pipefail
+
+db_password="${DB_PASSWORD:-mysecretpassword}"
+db_host="${DB_HOST:-localhost}"
+db_user="${DB_USER:-postgres}"
+db_name="${DB_NAME:-postgres}"
+db_port="${DB_PORT:-5432}"
+retries=0
+timeout="${DB_TIMEOUT:-20}"
+db_check_command="psql postgres://${db_user}:${db_password}@${db_host}:${db_port}/${db_name} -c 'select 1;' > /dev/null 2>&1"
+
+echo "> ${db_check_command}"
+echo -n "Checking for database connectivity.."
+
+while ! bash -c "$db_check_command"; do
+  retries=$(( retries + 1 ))
+  echo -n "."
+  if [[ $retries -eq $timeout ]]; then
+    echo "failed!"
+    exit 1
+  fi
+  sleep 1
+done
+
+echo "success!"


### PR DESCRIPTION
## [Ticket B-20145](https://www13.v1host.com/USTRANSCOM38/assetdetail.v1?number=B-20145) 

> [!TIP]
> This is valuable information for issues that will be encountered when we decide to automate 508 compliance and attempt local testing on the mymove repo

> [!NOTE]  
> The following discussion highlights limitations within the local environment. These issues DO NOT replicate in the live CircleCI environment. Please see more information in the relevant articles section.

# Summary

This reintroduces maven testing for the trdm pipeline by containerizing the CircleCI process, the milmove dependencies, and the postgres container for the test db.

A three container docker-in-docker approach was utilized due to known CircleCI CLI issues and limitations for local development preventing parallel images. These containers will use a remote docker setup with the CircleCI deprecated version 20. This parallel image error can easily be replicated by trying to run one of the mymove CircleCI jobs locally that use an executor with two images. 

The entire testing workflow was also put into a single job step due as workflows are another limitation that cannot run locally. By putting it all into a single job step, we include all dependencies meaning we can properly test in our local environments. The testing containers rely on the main mymove branch and execute migrations accordingly.

Workspaces and Docker volumes were not utilized due to additional restrictions encountered with host machine access, a workaround of input streaming was put in place to achieve the same functionality.

# How to test locally
-	Make sure CircleCI CLI is installed
-	Make sure Docker is running (Version doesn’t matter due to remote docker versioning)
-	Within the repository, run `circleci local execute test`

# Relevant Articles
Explaining the exact issue encountered
https://discuss.circleci.com/t/circleci-cli-error-response-from-daemon-invalid-uts-mode/48081

Open discussion detailing the parallel image
https://github.com/CircleCI-Public/circleci-cli/issues/970

Discussion detailing the last working docker version
https://github.com/andyatkinson/rideshare/issues/99

Marking 20.10.24 as the deprecated version 
https://circleci.com/docs/building-docker-images/#docker-version

Known CircleCI CLI local limitations
https://circleci.com/docs/how-to-use-the-circleci-local-cli/#limitations-of-running-jobs-locally
