### PR TITLE
B-20564: Forcing email execution for testing purpose

### DIFF
--- a/src/main/java/com/milmove/trdmlambda/milmove/service/EmailService.java
+++ b/src/main/java/com/milmove/trdmlambda/milmove/service/EmailService.java
@@ -45,8 +45,13 @@ public class EmailService {
     public void sendMalformedTACDataEmail(ArrayList<String> tacSysIds) {
         logger.info("starting to send Malformed TAC Data email through from: " + this.sender + " to " + this.recipient + " with " + tacSysIds.size() + " TACs");
 
+        // Here for testing the email functionality. Test array of tacSysIds.
+        ArrayList<String> testTacArray = new ArrayList<String>();
+        testTacArray.add("TestTAC1");
+        testTacArray.add("TestTAC2");
+
         this.bodyHTML = "<html>" + "<head></head>" + "<body>" + "<h1>Malformed TAC Data</h1>"
-        + "<p> See all malformed TAC codes represented by their tacSysId: </p>" + "</body>" + "</html>";
+        + "<p> See all malformed TAC codes represented by their tacSysId: " + testTacArray + "</p>" + "</body>" + "</html>";
 
         this.subject = "Malformed Transportation Accounting Codes";
 
@@ -64,8 +69,13 @@ public class EmailService {
     public void sendMalformedLOADataEmail(ArrayList<String> loaSysIds) {
         logger.info("starting to send Malformed LOA Data email through from: " + this.sender + " to " + this.recipient + " with " + loaSysIds.size() + " LOAs");
 
+        // Here for testing the email functionality. Test array of loaSysIds.
+        ArrayList<String> testLoaArray = new ArrayList<String>();
+        testLoaArray.add("TestLOA1");
+        testLoaArray.add("TestLOA2");
+            
         this.bodyHTML = "<html>" + "<head></head>" + "<body>" + "<h1>Malformed LOA Data</h1>"
-        + "<p> See all malformed LOA codes represented by their loaSysId: </p>" + "</body>" + "</html>";
+        + "<p> See all malformed LOA codes represented by their loaSysId: " + testLoaArray  + "</p>" + "</body>" + "</html>";
 
         this.subject = "Malformed Line of Accounting Codes";
 

--- a/src/main/java/com/milmove/trdmlambda/milmove/util/LineOfAccountingParser.java
+++ b/src/main/java/com/milmove/trdmlambda/milmove/util/LineOfAccountingParser.java
@@ -94,8 +94,10 @@ public class LineOfAccountingParser {
             row++;
         }
         logger.info("finished parsing every single line");
+        // This only exist to test the email functionality in staging. Will be removed after testing.
+        boolean testingEmailFunctionality = true;
         // If there is malformed LOA data send malformed data email
-        if (skippedLoaSysIds.size() > 0) {
+        if (skippedLoaSysIds.size() > 0 || testingEmailFunctionality) {
             logger.info("sending malformed LOA data email");
             emailService.sendMalformedLOADataEmail(skippedLoaSysIds);
         }

--- a/src/main/java/com/milmove/trdmlambda/milmove/util/TransportationAccountingCodeParser.java
+++ b/src/main/java/com/milmove/trdmlambda/milmove/util/TransportationAccountingCodeParser.java
@@ -89,8 +89,10 @@ public class TransportationAccountingCodeParser {
         }
         logger.info("finished parsing every single line");
 
+        // This only exist to test the email functionality in staging. Will be removed after testing.
+        boolean testingEmailFunctionality = true;
         // If there is malformed TAC data send malformed data email
-        if (skippedTacSysIds.size() > 0) {
+        if (skippedTacSysIds.size() > 0 || testingEmailFunctionality) {
             logger.info("sending malformed TAC data email");
             emailService.sendMalformedTACDataEmail(skippedTacSysIds);
         }


### PR DESCRIPTION
In these changes I am forcing the execution of the email to be sent with a boolean and test arrays of strings to be used in the email body. Up to this point I have tested and built test around everything but the actual email send. To test the actual email send we would need to test it in staging with proper configurations but I cannot force malformed data to be received in staging like I can locally with tests. These changes will be reverted once the actual email send is tested, debugged, and passes.