### PR TITLE
reintroduce tag filter to release workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -204,3 +204,5 @@ workflows:
           filters:
             branches:
               only: main
+            tags:
+              only: /^v.*/


### PR DESCRIPTION
Adding this filter back makes sure that on a new tag -> the workflow to release will be triggered

![image](https://github.com/user-attachments/assets/b2dd298b-6a29-42fb-b8ef-39325d4b856f)
