### PR TITLE
Removed the override and credentialProvider auth

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 	</parent>
 	<groupId>com.milmove.trdmlambda</groupId>
 	<artifactId>trdm-lambda</artifactId>
-	<version>1.0.3.13</version>
+	<version>1.0.3.14</version>
 	<name>trdm java spring interface</name>
 	<description>Project for deploying a Java TRDM interfacer for TGET data.</description>
 	<properties>

--- a/src/main/java/com/milmove/trdmlambda/milmove/service/EmailService.java
+++ b/src/main/java/com/milmove/trdmlambda/milmove/service/EmailService.java
@@ -34,11 +34,8 @@ public class EmailService {
 
     public EmailService() throws URISyntaxException {
         logger.info("starting initialization of Email Service");
-        String sesVPCEndpoint = "http://email-smtp.us-gov-west-1.amazonaws.com";
         this.sesClient = SesClient.builder()
                 .region(Region.of("us-gov-west-1"))
-                .credentialsProvider(DefaultCredentialsProvider.create())
-                .endpointOverride(new URI(sesVPCEndpoint))
                 .build();
 
         logger.info("finished initializing Email Service");


### PR DESCRIPTION
This was tested with a test lambda node.js implementation in AWS. The override was not needed and the credentialProvider for authenticating wasn't needed. Making the sesClient consistent with the tested node.js implementation.