### PR TITLE
upgrade to latest go for compiler

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 references:
-  circleci-docker: &circleci-docker milmove/circleci-docker:milmove-app-ab729849a08a773ea2557b19b67f378551d1ad3d
+  circleci-docker: &circleci-docker milmove/circleci-docker:milmove-app-3d9acdaa37c81a87b5fc1c6193a8e528dd56e4ed
   tf132-docker: &tf132-docker milmove/circleci-docker:milmove-infra-tf132-ab729849a08a773ea2557b19b67f378551d1ad3d
 
 executors:


### PR DESCRIPTION
Resolves the mymove binary not being compiled properly due to go mismatch of latest mymove repo and the circleci-docker container.


See https://app.circleci.com/pipelines/github/transcom/trdm-lambda/475/workflows/ed65facc-5863-4809-90e6-43158e3b05ae/jobs/827/parallel-runs/0/steps/0-111